### PR TITLE
Add Paperclip Configuration and Image Fingerprinting

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -60,6 +60,7 @@ group :test do
 end
 
 group :staging, :production do
+  gem "aws-sdk"
   gem "cf-app-utils"
   gem "rack-timeout"
   gem "rails_12factor"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -45,6 +45,12 @@ GEM
     autoprefixer-rails (6.3.4)
       execjs
     awesome_print (1.6.1)
+    aws-sdk (2.2.34)
+      aws-sdk-resources (= 2.2.34)
+    aws-sdk-core (2.2.34)
+      jmespath (~> 1.0)
+    aws-sdk-resources (2.2.34)
+      aws-sdk-core (= 2.2.34)
     bcrypt (3.1.11)
     bourbon (4.2.6)
       sass (~> 3.4)
@@ -141,11 +147,14 @@ GEM
       parser (>= 2.2.3.0)
       term-ansicolor (>= 1.3.2)
       terminal-table (>= 1.5.1)
+    jmespath (1.2.4)
+      json_pure (>= 1.8.1)
     jquery-rails (4.1.1)
       rails-dom-testing (>= 1, < 3)
       railties (>= 4.2.0)
       thor (>= 0.14, < 2.0)
     json (1.8.3)
+    json_pure (1.8.3)
     launchy (2.4.3)
       addressable (~> 2.3)
     loofah (2.0.3)
@@ -307,6 +316,7 @@ DEPENDENCIES
   airbrake (~> 4.3)
   autoprefixer-rails
   awesome_print
+  aws-sdk
   bourbon (~> 4.2.0)
   bundler-audit
   byebug

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -102,6 +102,7 @@ Rails.application.configure do
     },
     s3_headers: { "Cache-Control" => "max-age=#{1.year.to_i}" },
     s3_protocol: :https,
+    s3_region: "us-east-1",
     path: "uploads/:class/:attachment/:id_partition/:style/:basename-:fingerprint.:extension",
     use_timestamp: false
   }

--- a/db/migrate/20160415175058_add_logo_fingerprint_to_product.rb
+++ b/db/migrate/20160415175058_add_logo_fingerprint_to_product.rb
@@ -1,0 +1,9 @@
+class AddLogoFingerprintToProduct < ActiveRecord::Migration
+  def up
+    add_column :products, :logo_fingerprint, :string
+  end
+
+  def down
+    remove_column :products, :logo_fingerprint
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20160414211655) do
+ActiveRecord::Schema.define(version: 20160415175058) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -92,6 +92,7 @@ ActiveRecord::Schema.define(version: 20160414211655) do
     t.string   "logo_content_type"
     t.integer  "logo_file_size"
     t.datetime "logo_updated_at"
+    t.string   "logo_fingerprint"
   end
 
   create_table "users", force: :cascade do |t|


### PR DESCRIPTION
Adds the AWS region to the production environment. Also adds Md5 Checksum to logo uploads.

* Add AWS region to production
* Add MD5 Checksum to Logo