### PR TITLE
Govt. User Sign Up Redirect and Styles for Sign Up

### DIFF
--- a/app/assets/javascripts/registration.js
+++ b/app/assets/javascripts/registration.js
@@ -1,0 +1,19 @@
+var appsGov = appsGov || {};
+
+appsGov.registration = {
+  addActiveClassToFirstInput: function() {
+    $(".input:first").addClass("active");
+  },
+
+  bindInputFocusClass: function() {
+    $(".input input").on("focus", function() {
+      $(".input").removeClass("active");
+      $(this).parent(".input").addClass("active");
+    });
+  }
+};
+
+$(document).ready(function() {
+  appsGov.registration.bindInputFocusClass();
+  appsGov.registration.addActiveClassToFirstInput();
+});

--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -9,6 +9,7 @@
 @import "refills/flashes";
 @import "us-web-design-standards/uswds.min";
 
+@import "devise/*";
 @import "extends/*";
 @import "layouts/*";
 @import "modules/*";

--- a/app/assets/stylesheets/devise/_registration.scss
+++ b/app/assets/stylesheets/devise/_registration.scss
@@ -1,0 +1,123 @@
+.registrations-new {
+  background-color: darken($color-primary, 5);
+
+  .devise-links {
+    font-size: 0.9em;
+    text-align: center;
+  }
+
+  .form-actions {
+
+    input {
+      margin: 0.5em 0 1em;
+      max-width: none;
+      width: 100%;
+    }
+  }
+
+  .input {
+
+    &:first-child {
+      label {
+        margin-top: 0;
+      }
+    }
+
+    label,
+    .hint {
+      font-size: 0.9em;
+      font-weight: normal;
+      margin-top: 0.5em;
+    }
+
+    input {
+      background-color: $white;
+      border: 1px solid $light-gray;
+      border-radius: 0.25em;
+      padding-left: 3em;
+
+      &:focus {
+        box-shadow: none;
+      }
+    }
+  }
+
+  .usa-grid {
+    position: relative;
+
+    .sign-up-form {
+      box-shadow: 0 4px 5px rgba($black, 0.3);
+    }
+  }
+
+  .user_first_name,
+  .user_last_name,
+  .user_email,
+  .user_password {
+    position: relative;
+
+    &::before {
+      color: darken($light-gray, 5);
+      font-family: FontAwesome;
+      font-size: 1.2em;
+      height: 1em;
+      left: 0.75em;
+      position: absolute;
+      text-align: center;
+      top: 1.75em;
+      vertical-align: center;
+      width: 1em;
+    }
+
+    &.active {
+      &::before {
+        color: $color-primary;
+      }
+
+      input {
+        border: 1px solid $color-primary;
+      }
+    }
+  }
+
+  .user_email {
+    &::before {
+      content: "\f0e0";
+    }
+  }
+
+  .user_first_name,
+  .user_last_name {
+
+    &::before {
+      content: "\f007";
+    }
+  }
+
+  .user_password {
+    &::before {
+      content: "\f023";
+    }
+  }
+
+  .sign-up-form {
+    @extend %card;
+    border-radius: 0.3em;
+    left: 30em;
+    margin-left: -15em;
+    position: absolute;
+    top: 6em;
+    width: 30em;
+
+    .logo {
+      margin: 1em auto 0;
+      max-width: 10em;
+    }
+
+    h1 {
+      font-size: 1.25em;
+      font-weight: normal;
+      text-align: center;
+    }
+  }
+}

--- a/app/assets/stylesheets/uswds-overrides/overrides.scss
+++ b/app/assets/stylesheets/uswds-overrides/overrides.scss
@@ -7,6 +7,19 @@ figure {
   margin: 0;
 }
 
+form {
+  max-width: none;
+}
+
+input {
+
+  &[type="email"],
+  &[type="password"],
+  &[type="text"] {
+    max-width: none;
+  }
+}
+
 ul {
   display: block;
 

--- a/app/controllers/registration/government_employees_controller.rb
+++ b/app/controllers/registration/government_employees_controller.rb
@@ -1,0 +1,8 @@
+module Registration
+  class GovernmentEmployeesController < ApplicationController
+    def new
+      @govt_employee = GovtEmployee.new
+      @contract_officer = ContractOfficer.new
+    end
+  end
+end

--- a/app/controllers/registrations_controller.rb
+++ b/app/controllers/registrations_controller.rb
@@ -1,12 +1,26 @@
 class RegistrationsController < Devise::RegistrationsController
+  layout "minimal"
 
   private
 
-  def sign_up_params
-    params.require(:user).permit(:first_name, :last_name, :email, :password, :password_confirmation)
+  def account_update_params
+    params.require(:user).
+      permit(:first_name, :last_name, :email, :password, :current_password)
   end
 
-  def account_update_params
-    params.require(:user).permit(:first_name, :last_name, :email, :password, :password_confirmation, :current_password)
+  def after_sign_up_path_for(user)
+    if user_has_govt_email?(user.email)
+      registration_government_employee_path
+    else
+      root_path
+    end
+  end
+
+  def sign_up_params
+    params.require(:user).permit(:first_name, :last_name, :email, :password)
+  end
+
+  def user_has_govt_email?(email)
+    email.match(/(.+\.)?([^.]+)\.(?:gov|mil)$/).present?
   end
 end

--- a/app/views/devise/registrations/new.html.haml
+++ b/app/views/devise/registrations/new.html.haml
@@ -1,13 +1,18 @@
 .usa-grid
-  %h2 Sign up
-  = simple_form_for(resource, as: resource_name, url: registration_path(resource_name)) do |f|
-    = f.error_notification
-    .form-inputs
-      = f.input :first_name, required: true, autofocus: true
-      = f.input :last_name, required: true
-      = f.input :email, required: true
-      = f.input :password, required: true, hint: ("#{@minimum_password_length} characters minimum" if @minimum_password_length)
-      = f.input :password_confirmation, required: true
-    .form-actions
-      = f.button :submit, "Sign up"
-  = render "devise/shared/links"
+  .sign-up-form
+    %figure.logo
+      = link_to root_path do
+        = image_tag("logos/apps-logo-alt.svg")
+    %h1
+      = t(".heading")
+    = simple_form_for(resource, as: resource_name, url: registration_path(resource_name)) do |f|
+      = f.error_notification
+      .form-inputs
+        = f.input :first_name, required: true, autofocus: true
+        = f.input :last_name, required: true
+        = f.input :email, required: true
+        = f.input :password, required: true, hint: ("#{@minimum_password_length} characters minimum" if @minimum_password_length)
+      .form-actions
+        = f.button :submit, "Sign up"
+    .devise-links
+      = render "devise/shared/links"

--- a/app/views/layouts/minimal.html.haml
+++ b/app/views/layouts/minimal.html.haml
@@ -1,0 +1,17 @@
+!!!
+%html.no-js
+  %head
+    = render "modules/eagle"
+    %meta{ "charset" => "utf-8" }
+    %meta{ "name" => "ROBOTS", :content => "NOODP" }
+    %meta{ "name" => "viewport", :content => "initial-scale=1" }
+    %title
+      = title
+    = stylesheet_link_tag :application, media: "all"
+    = favicon_link_tag "favicons/favicon.ico"
+    = csrf_meta_tags
+  %body{ class: "#{body_class} #{static_page_body_class} minimal-layout".strip }
+    = render "flashes"
+    .page-content
+      = yield
+    = render "javascript"

--- a/app/views/registration/government_employees/new.html.haml
+++ b/app/views/registration/government_employees/new.html.haml
@@ -1,0 +1,3 @@
+%header
+  %h1
+    = t(".heading")

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -13,6 +13,11 @@ en:
       with_weekday:
         "%a %m/%d/%y"
 
+  devise:
+    registrations:
+      new:
+        heading: Sign up to start using the Apps.gov marketplace!
+
   modules:
     disclaimer:
       alt_text:
@@ -36,6 +41,11 @@ en:
       contact: Contact
     show:
       products: Products
+
+  registration:
+    government_employees:
+      new:
+        heading: Tell us a little about yourself
 
   time:
     formats:

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -5,5 +5,12 @@ Rails.application.routes.draw do
     resources :products, only: [:new, :create]
   end
 
+  namespace :registration do
+    get \
+      "/government-employees",
+      to: "government_employees#new",
+      as: :government_employee
+  end
+
   resources :products, only: [:index, :show]
 end

--- a/spec/features/user_signs_up_spec.rb
+++ b/spec/features/user_signs_up_spec.rb
@@ -1,17 +1,36 @@
 require "rails_helper"
 
-feature "User Sign Up" do
-  scenario "a User creates an account" do
-    visit new_user_registration_path
+feature "A User signs up" do
+  context "with a government email address" do
+    scenario "and creates an account" do
+      visit new_user_registration_path
 
-    fill_in "First name", with: "John"
-    fill_in "Last name", with: "Doe"
-    fill_in "Email", with: "email@email.com"
-    fill_in "Password", with: "12345sixsevenEight", match: :prefer_exact
-    fill_in "Password confirmation", with: "12345sixsevenEight"
+      fill_in "First name", with: "John"
+      fill_in "Last name", with: "Doe"
+      fill_in "Email", with: "email@email.gov"
+      fill_in "Password", with: "12345sixsevenEight", match: :prefer_exact
 
-    click_on "Sign up"
+      click_on "Sign up"
 
-    expect(page).to have_text t("devise.registrations.signed_up")
+      expect(page).
+        to have_text t("devise.registrations.signed_up")
+      expect(page).
+        to have_text t("registration.government_employees.new.heading")
+    end
+  end
+
+  context "without a government email address" do
+    scenario "and creates an account" do
+      visit new_user_registration_path
+
+      fill_in "First name", with: "John"
+      fill_in "Last name", with: "Doe"
+      fill_in "Email", with: "email@email.com"
+      fill_in "Password", with: "12345sixsevenEight", match: :prefer_exact
+
+      click_on "Sign up"
+
+      expect(page).to have_text t("devise.registrations.signed_up")
+    end
   end
 end

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -40,5 +40,5 @@ Capybara.javascript_driver = :webkit
 
 Capybara::Webkit.configure do |config|
   config.allow_url("#{ENV['ALGOLIA_APP_ID'].downcase}-dsn.algolia.net")
-  config.allow_url("#{ENV['ALGOLIA_APP_ID'].downcase}-2.algolia.net")
+  config.allow_url("#{ENV['ALGOLIA_APP_ID'].downcase}-2.algolianet.com")
 end


### PR DESCRIPTION
Adds a second-level domain check on a User's email on sign up to determine if a User is a government employee or not. Also adds a new minimal layout and styles for the New Registration view.

* Add SLD domain check on User's email during signup for role-specific redirects and assignment
* Create minimal layout and implement in Registration Controller
* Add styles for New Registration view