### PR TITLE
Add Confirmation To User

### DIFF
--- a/app/assets/javascripts/confirm.js
+++ b/app/assets/javascripts/confirm.js
@@ -1,0 +1,14 @@
+var appsGov = appsGov || {};
+
+appsGov.confirm = {
+
+  bindConfirmClose: function() {
+    $("#close-confirm").on("click", function() {
+      $(".confirm-account").removeClass("active");
+    });
+  }
+};
+
+$(document).ready(function() {
+  appsGov.confirm.bindConfirmClose();
+});

--- a/app/assets/stylesheets/modules/_confirm.scss
+++ b/app/assets/stylesheets/modules/_confirm.scss
@@ -1,0 +1,38 @@
+.confirm-account {
+  @include transition(all 0.15s ease);
+  @include transform(translateX(-20em));
+  background-color: $color-primary;
+  color: $white;
+  left: 0;
+  opacity: 0;
+  padding: 0.75em 1em;
+  position: fixed;
+  top: 5.65em;
+  visibility: hidden;
+  width: 15em;
+  z-index: 1000;
+
+  &.active {
+    @include transform(translateX(0));
+    opacity: 1;
+    visibility: visible;
+  }
+
+  h3 {
+    font-size: 0.9em;
+    margin: 0 0 0.1em;
+  }
+
+  p {
+    font-size: 0.8em;
+    margin: 0;
+  }
+
+  .close-confirm {
+    cursor: pointer;
+    font-size: 1.1em;
+    position: absolute;
+    right: 0.25em;
+    top: 0.1em;
+  }
+}

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -3,10 +3,6 @@ module ApplicationHelper
     "#{static_page_body_class} #{sign_in_status}"
   end
 
-  def devise_mapping
-    Devise.mappings[:user]
-  end
-
   def no_users_signed_in?
     !user_signed_in? && !government_user_signed_in?
   end
@@ -18,7 +14,7 @@ module ApplicationHelper
   end
 
   def sign_in_status
-    if user_signed_in? || government_user_signed_in?
+    if signed_in?
       "signed-in"
     end
   end

--- a/app/helpers/devise_helper.rb
+++ b/app/helpers/devise_helper.rb
@@ -1,0 +1,13 @@
+module DeviseHelper
+  def devise_mapping
+    Devise.mappings[:user]
+  end
+
+  def hours_since_sign_up
+    (((signed_in_user.created_at + 2.days) - Time.now) / 3600).round * 1
+  end
+
+  def signed_in_user
+    current_user || current_government_user
+  end
+end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -1,7 +1,7 @@
 class User < ActiveRecord::Base
   # Include default devise modules. Others available are:
   # :confirmable, :lockable, :timeoutable and :omniauthable
-  devise :database_authenticatable, :registerable,
+  devise :confirmable, :database_authenticatable, :registerable,
          :recoverable, :rememberable, :trackable, :validatable
 
   validates :first_name, :last_name, presence: true

--- a/app/views/layouts/application.html.haml
+++ b/app/views/layouts/application.html.haml
@@ -12,6 +12,7 @@
     = csrf_meta_tags
   %body{ class: "#{body_class} #{custom_body_class} default-layout".strip }
     = render "modules/navigation"
+    = render "modules/confirm"
     = render "flashes"
     .page-content
       = yield

--- a/app/views/modules/_confirm.html.haml
+++ b/app/views/modules/_confirm.html.haml
@@ -1,0 +1,8 @@
+- if signed_in? && signed_in_user.confirmed_at.nil?
+  .confirm-account.active
+    %h3
+      = t(".heading")
+    %p
+      = t(".description", hours: pluralize(hours_since_sign_up, t(".hours")))
+    .close-confirm#close-confirm
+      %i.fa.fa-times-circle-o

--- a/config/initializers/devise.rb
+++ b/config/initializers/devise.rb
@@ -107,7 +107,7 @@ Devise.setup do |config|
   # able to access the website for two days without confirming their account,
   # access will be blocked just in the third day. Default is 0.days, meaning
   # the user cannot access the website without confirming their account.
-  # config.allow_unconfirmed_access_for = 2.days
+  config.allow_unconfirmed_access_for = 2.days
 
   # A period that the user is allowed to confirm their account before their
   # token becomes invalid. For example, if set to 3.days, the user can confirm
@@ -121,7 +121,7 @@ Devise.setup do |config|
   # initial account confirmation) to be applied. Requires additional unconfirmed_email
   # db field (see migrations). Until confirmed, new email is stored in
   # unconfirmed_email column, and copied to email column on successful confirmation.
-  config.reconfirmable = true
+  config.reconfirmable = false
 
   # Defines which key will be used when confirming an account
   # config.confirmation_keys = [:email]

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -31,6 +31,12 @@ en:
         heading: Sign up to start using the Apps.gov marketplace!
 
   modules:
+    confirm:
+      description:
+        You have %{hours} left to verify your account. Please check your inbox
+        now.
+      heading: Verify Your Account
+      hours: hours
     disclaimer:
       alt_text:
         US flag signifying that this is a United States Federal Government

--- a/db/migrate/20160427193154_add_confirmable_to_user.rb
+++ b/db/migrate/20160427193154_add_confirmable_to_user.rb
@@ -1,0 +1,13 @@
+class AddConfirmableToUser < ActiveRecord::Migration
+  def up
+    add_column :users, :confirmation_token, :string
+    add_column :users, :confirmed_at, :datetime
+    add_column :users, :confirmation_sent_at, :datetime
+    add_index :users, :confirmation_token, unique: true
+    execute("UPDATE users SET confirmed_at = NOW()")
+  end
+
+  def down
+    remove_columns :users, :confirmation_token, :confirmed_at, :confirmation_sent_at
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20160426183514) do
+ActiveRecord::Schema.define(version: 20160427193154) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -133,9 +133,13 @@ ActiveRecord::Schema.define(version: 20160426183514) do
     t.boolean  "admin",                  default: false, null: false
     t.integer  "agency_id"
     t.string   "type"
+    t.string   "confirmation_token"
+    t.datetime "confirmed_at"
+    t.datetime "confirmation_sent_at"
   end
 
   add_index "users", ["agency_id"], name: "index_users_on_agency_id", using: :btree
+  add_index "users", ["confirmation_token"], name: "index_users_on_confirmation_token", unique: true, using: :btree
   add_index "users", ["email"], name: "index_users_on_email", unique: true, using: :btree
   add_index "users", ["reset_password_token"], name: "index_users_on_reset_password_token", unique: true, using: :btree
 

--- a/spec/factories/users.rb
+++ b/spec/factories/users.rb
@@ -8,5 +8,11 @@ FactoryGirl.define do
     trait :as_gov_user do
       type "GovernmentUser"
     end
+
+    trait :verified do
+      after(:build) do |user|
+        user.confirm
+      end
+    end
   end
 end

--- a/spec/features/user_sign_in_spec.rb
+++ b/spec/features/user_sign_in_spec.rb
@@ -31,8 +31,31 @@ feature "User Sign In" do
       within("div#sign-in-modal") do
         click_on t("devise.sessions.form.sign_in")
       end
-      expect(page).to have_text "Signed in successfully"
+      expect(page).to have_text t("devise.sessions.signed_in")
     end
+  end
+
+  context "when a User has not confirmed their account for more than 2 days" do
+    scenario "they can no longer sign in" do
+      Timecop.travel(two_days_after_signup) do
+        visit products_path
+
+        within("nav.app-nav") do
+          click_on t("modules.navigation.sign_in")
+        end
+
+        fill_in "Email", with: user.email
+        fill_in "Password", with: user.password
+
+        click_on t("devise.sessions.form.sign_in")
+
+        expect(page).to have_text t("devise.failure.unconfirmed")
+      end
+    end
+  end
+
+  def two_days_after_signup
+    user.created_at + 2.days
   end
 
   def user

--- a/spec/features/user_signs_up_spec.rb
+++ b/spec/features/user_signs_up_spec.rb
@@ -13,5 +13,13 @@ feature "A User signs up" do
 
     expect(page).
       to have_text t("devise.registrations.signed_up")
+    expect(last_email.to).
+      to eq ["email@email.gov"]
+    expect(last_email.subject).
+      to eq t("devise.mailer.confirmation_instructions.subject")
+  end
+
+  def last_email
+    ActionMailer::Base.deliveries.last
   end
 end

--- a/spec/features/user_verifies_account_spec.rb
+++ b/spec/features/user_verifies_account_spec.rb
@@ -1,0 +1,29 @@
+require "rails_helper"
+
+feature "Account Verification" do
+  context "when a User has not verified their account" do
+    before { login_as(unverified_user, scope: :government_user) }
+    scenario "they see a verify account message" do
+      visit root_path
+
+      expect(page).to have_text t("modules.confirm.heading")
+    end
+  end
+
+  context "when a User has verified their account" do
+    before { login_as(verified_user, scope: :government_user) }
+    scenario "they do not see a verify account message" do
+      visit root_path
+
+      expect(page).to_not have_text t("modules.confirm.heading")
+    end
+  end
+
+  def unverified_user
+    @unverified_user ||= create(:user, :as_gov_user)
+  end
+
+  def verified_user
+    @verified_user ||= create(:user, :as_gov_user, :verified)
+  end
+end


### PR DESCRIPTION
Adds confirmable to the User model and enables Users to use the app for a grace period before cancelling their account.

* Add confirmable to User
* Add verify your account message to all pages when a User is signed in but not confirmed
* Add Javascript for closing the confirm message