### PR TITLE
Remove Request Product Button if Requested

### DIFF
--- a/app/assets/stylesheets/products/_show.scss
+++ b/app/assets/stylesheets/products/_show.scss
@@ -30,19 +30,30 @@
     position: absolute;
     right: 0;
 
+    a,
     button {
       @include outline-button($medium-gray);
       margin: 0;
       padding: 0.5em 0.75em;
 
-      &[type="submit"] {
-        background-color: transparent;
-      }
-
       &:hover {
         background-color: $color-primary;
         color: $white;
         text-decoration: none;
+      }
+
+      &[type="submit"] {
+        background-color: transparent;
+      }
+
+      &.requested {
+        @include outline-button($color-primary);
+        margin: 0;
+        padding: 0.5em 0.75em;
+
+        &:hover {
+          color: $white;
+        }
       }
     }
 

--- a/app/helpers/product_helper.rb
+++ b/app/helpers/product_helper.rb
@@ -1,0 +1,5 @@
+module ProductHelper
+  def product_belongs_to_user?(product)
+    ProductRequest.exists?(user_id: signed_in_user, product_id: product.id)
+  end
+end

--- a/app/models/product.rb
+++ b/app/models/product.rb
@@ -37,22 +37,22 @@ class Product < ActiveRecord::Base
     add_attribute :logo_url
   end
 
-  def self.trigger_delayed_job(record, remove)
-    if remove
-      record.delay.remove_from_index!
-    else
-      record.delay.index!
-    end
+  def self.most_popular
+    includes(:users).
+      where("users.type" => "GovernmentUser").
+      order("product_requests_count DESC").limit(3)
   end
 
   def self.search(query)
     where("name LIKE ?", "%#{query}%")
   end
 
-  def self.most_popular
-    includes(:users).
-      where("users.type" => "GovernmentUser").
-      order("product_requests_count DESC").limit(3)
+  def self.trigger_delayed_job(record, remove)
+    if remove
+      record.delay.remove_from_index!
+    else
+      record.delay.index!
+    end
   end
 
   def logo_url

--- a/app/views/products/_product_content.html.haml
+++ b/app/views/products/_product_content.html.haml
@@ -10,6 +10,10 @@
         - if no_users_signed_in?
           = button_tag(class: "modal-trigger", data: {modal_id: "product-owner-signup-modal"}, id: "edit-product-button", type: "submit") do
             = t(".edit_product_html")
+        - elsif product_belongs_to_user?(product)
+          = link_to product_owner_dashboard_path, class: "requested" do
+            %i.fa.fa-check
+            = t(".requested")
         - else
           = button_tag(id: "edit-product-button", type: "submit") do
             = t(".edit_product_html")

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -91,6 +91,7 @@ en:
         Find the products you need to build, communicate, and deliver faster.
     product_content:
       edit_product_html: <i class="fa fa-pencil"></i>Request to Edit
+      requested: Product Requested
     product_owner_modal:
       heading: Sign Up to Edit Products on Apps.gov
     product_sidebar:

--- a/spec/features/product_owners/product_owner_creates_a_product_request_spec.rb
+++ b/spec/features/product_owners/product_owner_creates_a_product_request_spec.rb
@@ -3,15 +3,27 @@ require "rails_helper"
 feature "Product Owner Creates Product Request" do
   before { login_as(product_owner, scope: :product_owner) }
 
-  scenario "by clicking the Edit button" do
-    visit product_path(product)
+  context "when the Product has been requested" do
+    scenario "and does not see the Request to Edit button" do
+      create(:product_request, product: product, user: product_owner)
+      visit product_path(product)
 
-    click_on "Edit"
+      expect(page).to_not have_selector(:link_or_button, "Edit")
+      expect(page).to have_text t("products.product_content.requested")
+    end
+  end
 
-    expect(page).
-      to have_text t("product_owners.product_requests.create.success")
-    expect(page).
-      to have_text t("product_owners.dashboard.index.heading")
+  context "when the Product has not been requested" do
+    scenario "by clicking the Edit button" do
+      visit product_path(product)
+
+      click_on "Edit"
+
+      expect(page).
+        to have_text t("product_owners.product_requests.create.success")
+      expect(page).
+        to have_text t("product_owners.dashboard.index.heading")
+    end
   end
 
   def product


### PR DESCRIPTION
Removes the Request Product Button and replaces it with a link to the Product Owner Dashboard if the Product has already been requested.

* Add conditional to determine if Product has already been requested
* If requested, hide the Product Request button and replace with a link to the Product Owner Dashboard