### PR TITLE
Admin Destroys ProductRequest

### DIFF
--- a/app/assets/stylesheets/admin/product_requests/_edit.scss
+++ b/app/assets/stylesheets/admin/product_requests/_edit.scss
@@ -1,0 +1,14 @@
+.admin-product_requests-edit {
+
+  .form-actions {
+
+    a {
+      padding: 0.75em 2.7em;
+    }
+
+    a,
+    input[type="submit"] {
+      display: inline-block;
+    }
+  }
+}

--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -9,6 +9,7 @@
 @import "refills/flashes";
 @import "us-web-design-standards/uswds.min";
 
+@import "admin/product_requests/*";
 @import "animations/*";
 @import "categories/*";
 @import "devise/*";

--- a/app/controllers/admin/product_requests_controller.rb
+++ b/app/controllers/admin/product_requests_controller.rb
@@ -12,9 +12,27 @@ module Admin
         flash[:success] = I18n.t("admin.product_requests.update.success")
         redirect_to admin_dashboard_path
       else
-        flash[:success] = I18n.t("admin.product_requests.update.error")
+        flash[:error] = I18n.t("admin.product_requests.update.error")
         render :edit
       end
+    end
+
+    def destroy
+      @product_request = ProductRequest.find(params[:id])
+
+      if @product_request.destroy!
+        flash[:success] = I18n.t("admin.product_requests.destroy.success")
+        redirect_to admin_dashboard_path
+      else
+        flash[:error] = I18n.t("admin.product_requests.destroy.error")
+        render :edit
+      end
+    end
+
+    private
+
+    def product_request
+      @product_request ||= ProductRequest.find(params[:product_request_id])
     end
   end
 end

--- a/app/views/admin/product_requests/edit.html.haml
+++ b/app/views/admin/product_requests/edit.html.haml
@@ -13,4 +13,10 @@
           = t(".product")
         = render "product_info", product: @product_request.product
 
-      = f.submit t(".approve")
+      .form-actions
+        = f.submit t(".approve")
+        = link_to t(".reject"),
+          admin_product_request_path(@product_request),
+          class: "usa-button usa-button-secondary",
+          data: {confirm: t(".confirm_destroy")},
+          method: :delete

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -16,10 +16,15 @@ en:
         product_name: Product Name
         requester: Requested By
     product_requests:
+      destroy:
+        error: Something went wrong. Please try again.
+        success: Product Request rejected!
       edit:
         approve: Approve Request
+        confirm_destroy: Are you sure you want to remove this Request?
         header: Product Request
         product: Product Info
+        reject: Reject Request
         user: User Info
       product_info:
         name: Name

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -14,7 +14,7 @@ Rails.application.routes.draw do
   end
 
   namespace :admin do
-    resources :product_requests, only: [:edit, :update]
+    resources :product_requests, only: [:edit, :update, :destroy]
     resources :products, only: [:create, :edit, :new, :update]
   end
 

--- a/db/migrate/20160614174335_add_trashed_at_to_product_request.rb
+++ b/db/migrate/20160614174335_add_trashed_at_to_product_request.rb
@@ -1,0 +1,5 @@
+class AddTrashedAtToProductRequest < ActiveRecord::Migration
+  def change
+    add_column :product_requests, :trashed_at, :timestamp
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20160603191105) do
+ActiveRecord::Schema.define(version: 20160614174335) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -127,6 +127,7 @@ ActiveRecord::Schema.define(version: 20160603191105) do
     t.integer  "user_id",      null: false
     t.integer  "draft_id"
     t.datetime "published_at"
+    t.datetime "trashed_at"
   end
 
   add_index "product_requests", ["product_id"], name: "index_product_requests_on_product_id", using: :btree

--- a/spec/features/admins/admin_rejects_product_request_spec.rb
+++ b/spec/features/admins/admin_rejects_product_request_spec.rb
@@ -1,0 +1,31 @@
+require "rails_helper"
+
+feature "Admin Rejects Product Request" do
+  before do
+    login_as(admin, scope: :user)
+    product_request
+  end
+
+  scenario "and no longer sees the Product Request in the Dashboard" do
+    visit admin_dashboard_path
+
+    click_on product_request.name
+
+    click_on t("admin.product_requests.edit.reject")
+
+    expect(page).to have_text t("admin.product_requests.destroy.success")
+  end
+
+  def admin
+    @admin ||= create(:user, admin: true)
+  end
+
+  def product_owner
+    @product_owner ||= create(:user, type: "ProductOwner")
+  end
+
+  def product_request
+    @product_request ||=
+      create(:product_request, :with_draft, user: product_owner)
+  end
+end

--- a/spec/features/product_owners/product_owner_creates_a_product_request_spec.rb
+++ b/spec/features/product_owners/product_owner_creates_a_product_request_spec.rb
@@ -4,7 +4,7 @@ feature "Product Owner Creates Product Request" do
   before { login_as(product_owner, scope: :product_owner) }
 
   context "when the Product has been requested" do
-    scenario "and does not see the Request to Edit button" do
+    scenario "the Product Owner does not see an Edit button" do
       create(:product_request, product: product, user: product_owner)
       visit product_path(product)
 
@@ -14,7 +14,7 @@ feature "Product Owner Creates Product Request" do
   end
 
   context "when the Product has not been requested" do
-    scenario "by clicking the Edit button" do
+    scenario "a ProductOwner can request the Product" do
       visit product_path(product)
 
       click_on "Request to Edit"


### PR DESCRIPTION
Enables Admins to Destroy ProductRequests from Product Owners

* Add destroy action to Admin ProductRequest controller
* Add link to delete ProductRequest to ProductRequest edit view