### PR TITLE
Admin Rejects Product Edits

### DIFF
--- a/app/controllers/admin/dashboard_controller.rb
+++ b/app/controllers/admin/dashboard_controller.rb
@@ -5,7 +5,7 @@ module Admin
         ProductRequest.joins(:product, :user).
         where("users.type = 'ProductOwner'").drafted
       @product_drafts =
-        Draftsman::Draft.includes(:item).where(item_type: "Product")
+        Draftsman::Draft.includes(:item).where(item_type: "Product", rejected: false)
     end
   end
 end

--- a/app/controllers/admin/messages_controller.rb
+++ b/app/controllers/admin/messages_controller.rb
@@ -1,0 +1,28 @@
+module Admin
+  class MessagesController < AdminController
+    def new
+      @message = Message.new
+      @product = Product.find(params[:product_id])
+    end
+
+    def create
+      @message = Message.new(message_params)
+      @product = Product.find(params[:product_id])
+      @product_rejection = ProductRejection.new(@message, @product)
+
+      if @product_rejection.create?
+        flash[:success] = I18n.t("admin.messages.create.success")
+        redirect_to dashboard_path
+      else
+        flash[:error] = I18n.t("admin.messages.create.error")
+        render :new
+      end
+    end
+
+    private
+
+    def message_params
+      params.require(:message).permit(:content).merge(author: current_user)
+    end
+  end
+end

--- a/app/models/message.rb
+++ b/app/models/message.rb
@@ -1,0 +1,5 @@
+class Message < ActiveRecord::Base
+  belongs_to :author, class_name: "User", foreign_key: "author_id"
+
+  validates :author, :content, presence: true
+end

--- a/app/models/product_rejection.rb
+++ b/app/models/product_rejection.rb
@@ -1,0 +1,12 @@
+class ProductRejection
+  def initialize(message, product)
+    @message = message
+    @product = product
+  end
+
+  def create?
+    if @message.save!
+      @product.draft.update_attributes(rejected: true)
+    end
+  end
+end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -7,6 +7,7 @@ class User < ActiveRecord::Base
   validates :first_name, :last_name, presence: true
 
   belongs_to :agency
+  has_many :messages
   has_many :products, through: :product_requests
   has_many :product_requests
 

--- a/app/views/admin/messages/new.html.haml
+++ b/app/views/admin/messages/new.html.haml
@@ -1,0 +1,10 @@
+.usa-grid
+  %header
+    %h1
+      = t(".header")
+    %p
+      = t(".description")
+
+  = simple_form_for [:admin, @product, @message] do |f|
+    = f.input :content, label: t(".content")
+    = f.submit t(".submit")

--- a/app/views/admin/products/edit.html.haml
+++ b/app/views/admin/products/edit.html.haml
@@ -6,3 +6,4 @@
       = render "product_table", product_draft: @product_draft
 
       = f.submit t(".submit")
+      = link_to t(".reject"), new_admin_product_message_path(@product)

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -15,6 +15,17 @@ en:
         no_requests: No outstanding Product drafts were found.
         product_name: Product Name
         requester: Requested By
+    messages:
+      create:
+        error: Something went wrong. Please try again.
+        success: Product edits rejected.
+      new:
+        content: Reason for Rejection
+        description:
+          To reject these Product edits, provide a reason that will be sent to
+          the Product’s Owner.
+        header: Reject Product Edits
+        submit: Reject Edits
     product_requests:
       destroy:
         error: Something went wrong. Please try again.
@@ -40,6 +51,7 @@ en:
         success_message: Product created!
       edit:
         header: Approve Product
+        reject: Reject Edits
         submit: Approve Changes
       new:
         header: Create a Product

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -15,7 +15,9 @@ Rails.application.routes.draw do
 
   namespace :admin do
     resources :product_requests, only: [:edit, :update, :destroy]
-    resources :products, only: [:create, :edit, :new, :update]
+    resources :products, only: [:create, :edit, :new, :update] do
+      resources :messages, only: [:create, :new]
+    end
   end
 
   namespace :product_owners do

--- a/db/migrate/20160615150054_create_messages.rb
+++ b/db/migrate/20160615150054_create_messages.rb
@@ -1,0 +1,8 @@
+class CreateMessages < ActiveRecord::Migration
+  def change
+    create_table :messages do |t|
+      t.belongs_to :author, null: false
+      t.text :content, null: false
+    end
+  end
+end

--- a/db/migrate/20160615164348_add_rejected_to_draft.rb
+++ b/db/migrate/20160615164348_add_rejected_to_draft.rb
@@ -1,0 +1,5 @@
+class AddRejectedToDraft < ActiveRecord::Migration
+  def change
+    add_column :drafts, :rejected, :boolean, default: false, null: false
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20160614174335) do
+ActiveRecord::Schema.define(version: 20160615164348) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -77,15 +77,16 @@ ActiveRecord::Schema.define(version: 20160614174335) do
   add_index "delayed_jobs", ["priority", "run_at"], name: "delayed_jobs_priority", using: :btree
 
   create_table "drafts", force: :cascade do |t|
-    t.string   "item_type",      null: false
-    t.integer  "item_id",        null: false
-    t.string   "event",          null: false
+    t.string   "item_type",                      null: false
+    t.integer  "item_id",                        null: false
+    t.string   "event",                          null: false
     t.string   "whodunnit"
     t.text     "object"
     t.text     "previous_draft"
-    t.datetime "created_at",     null: false
-    t.datetime "updated_at",     null: false
+    t.datetime "created_at",                     null: false
+    t.datetime "updated_at",                     null: false
     t.json     "object_changes"
+    t.boolean  "rejected",       default: false, null: false
   end
 
   add_index "drafts", ["created_at"], name: "index_drafts_on_created_at", using: :btree
@@ -99,6 +100,11 @@ ActiveRecord::Schema.define(version: 20160614174335) do
     t.string   "name",       null: false
     t.datetime "created_at"
     t.datetime "updated_at"
+  end
+
+  create_table "messages", force: :cascade do |t|
+    t.integer "author_id", null: false
+    t.text    "content",   null: false
   end
 
   create_table "product_categories", force: :cascade do |t|

--- a/spec/factories/message.rb
+++ b/spec/factories/message.rb
@@ -1,0 +1,7 @@
+FactoryGirl.define do
+  factory :message do
+    content "Content"
+
+    author
+  end
+end

--- a/spec/factories/users.rb
+++ b/spec/factories/users.rb
@@ -1,9 +1,13 @@
 FactoryGirl.define do
-  factory :user do
+  factory :user, aliases: [:author] do
     first_name "John"
     last_name "Doe"
     password "12345sixSevenEight"
     sequence(:email) { |n| "email#{n}@apps.com" }
+
+    trait :as_admin do
+      admin true
+    end
 
     trait :as_gov_user do
       type "GovernmentUser"

--- a/spec/features/admins/admin_rejects_product_draft_spec.rb
+++ b/spec/features/admins/admin_rejects_product_draft_spec.rb
@@ -1,0 +1,24 @@
+require "rails_helper"
+
+feature "Admin Rejects Product Draft" do
+  before { login_as(admin, scope: :user) }
+
+  scenario "and provides a reason for doing so" do
+    product = create(:product, :with_draft)
+
+    visit dashboard_path
+    click_on product.name
+
+    click_on t("admin.products.edit.reject")
+
+    fill_in t("admin.messages.new.content"), with: "The content is inappropriate."
+    click_on t("admin.messages.new.submit")
+
+    expect(page).to have_text t("admin.messages.create.success")
+    expect(page).not_to have_text product.name
+  end
+
+  def admin
+    @admin ||= create(:user, admin: true)
+  end
+end

--- a/spec/models/product_rejection_spec.rb
+++ b/spec/models/product_rejection_spec.rb
@@ -1,0 +1,30 @@
+require "rails_helper"
+
+describe ProductRejection do
+  describe "create?" do
+    before do
+      allow(Message).to receive(:new).and_return(message)
+      allow(message).to receive(:save!).and_return(true)
+      ProductRejection.new(message, product).create?
+    end
+    it "creates a Message" do
+      expect(message).to have_received(:save!)
+    end
+
+    it "rejects the Product Draft" do
+      expect(product.draft.rejected).to eq(true)
+    end
+  end
+
+  def message
+    @message ||= build(:message, author: user)
+  end
+
+  def product
+    @product ||= create(:product, :with_draft)
+  end
+
+  def user
+    @user ||= create(:user, :as_admin)
+  end
+end


### PR DESCRIPTION
An Admin can reject Product Edits without destroying the Draft.

* Create ProductRejection model for handling the rejection of a Product Draft
* Create Message to be used for custom messages to be sent to ProductOwners when their Draft is rejected