### PR TITLE
Send Rejection Email to Product Owner

### DIFF
--- a/app/mailers/rejection_mailer.rb
+++ b/app/mailers/rejection_mailer.rb
@@ -1,0 +1,13 @@
+class RejectionMailer < BaseMandrillMailer
+  def send_email(message, product, user)
+    subject = t(".subject")
+    merge_vars = {
+      "FIRST_NAME" => user.first_name,
+      "MESSAGE" => message.content,
+      "PRODUCT_NAME" => product.name
+    }
+    body = mandrill_template("apps-gov-rejection", merge_vars)
+
+    send_mail(user, subject, body)
+  end
+end

--- a/app/models/product_rejection.rb
+++ b/app/models/product_rejection.rb
@@ -7,6 +7,7 @@ class ProductRejection
   def create?
     if @message.save!
       @product.draft.update_attributes(rejected: true)
+      RejectionMailer.send_email(@message, @product, @message.author)
     end
   end
 end

--- a/config/i18n-tasks.yml
+++ b/config/i18n-tasks.yml
@@ -8,6 +8,7 @@ search:
 ignore_unused:
   - activerecord.*
   - date.*
+  - rejection_mailer.*
   - simple_form.*
   - time.*
   - titles.*

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -182,6 +182,10 @@ en:
       new:
         heading: Tell us a little about yourself
 
+  rejection_mailer:
+    send_email:
+      subject: Your Product Edits Have Been Rejected
+
   time:
     formats:
       default:

--- a/spec/mailers/rejection_mailer_spec.rb
+++ b/spec/mailers/rejection_mailer_spec.rb
@@ -1,0 +1,21 @@
+require "rails_helper"
+
+describe RejectionMailer do
+  describe "#send_email" do
+    include ActionView::Helpers::UrlHelper
+
+    it "sends an email with the correct information" do
+      user = create(:user)
+      product = create(:product)
+      message = create(:message, author: user)
+      mail = described_class.send_email(message, product, user)
+
+      expect(mail.to).to include user.email
+      expect(mail.from).to include ENV.fetch("MAILER_FROM_EMAIL")
+      expect(mail.subject).to eq t("rejection_mailer.send_email.subject")
+      expect(mail.body).to include user.first_name
+      expect(mail.body).to include product.name
+      expect(mail.body).to include message.content
+    end
+  end
+end


### PR DESCRIPTION
Sends a Rejection Email to a Product Owner when their edits have been rejected.

* Send Rejection Email to Product Owner with message