### PR TITLE
ProductRequest Success Mailer

### DIFF
--- a/app/controllers/admin/product_requests_controller.rb
+++ b/app/controllers/admin/product_requests_controller.rb
@@ -7,8 +7,10 @@ module Admin
 
     def update
       @product_request = ProductRequest.find(params[:id])
+      @product = @product_request.product
 
       if @product_request.draft.publish!
+        ProductRequestMailer.send_email(@product, @product_request.user)
         flash[:success] = I18n.t("admin.product_requests.update.success")
         redirect_to admin_dashboard_path
       else

--- a/app/mailers/product_request_mailer.rb
+++ b/app/mailers/product_request_mailer.rb
@@ -1,0 +1,12 @@
+class ProductRequestMailer < BaseMandrillMailer
+  def send_email(product, user)
+    subject = t(".subject")
+    merge_vars = {
+      "FIRST_NAME" => user.first_name,
+      "PRODUCT_NAME" => product.name
+    }
+    body = mandrill_template("apps-gov-product-request", merge_vars)
+
+    send_mail(user, subject, body)
+  end
+end

--- a/config/i18n-tasks.yml
+++ b/config/i18n-tasks.yml
@@ -8,6 +8,7 @@ search:
 ignore_unused:
   - activerecord.*
   - date.*
+  - product_request_mailer.*
   - rejection_mailer.*
   - simple_form.*
   - time.*

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -148,6 +148,10 @@ en:
       new:
         heading: Sign up to list your product Apps.gov marketplace!
 
+  product_request_mailer:
+    send_email:
+      subject: Editing Privileges Granted
+
   product_requests:
     create:
       failure: An error occured. Please try again.

--- a/spec/controllers/admin/product_requests_controller_spec.rb
+++ b/spec/controllers/admin/product_requests_controller_spec.rb
@@ -1,0 +1,22 @@
+require "rails_helper"
+
+describe Admin::ProductRequestsController do
+  describe "#update" do
+    it "sends an email when successful" do
+      sign_in_user(admin)
+      allow(ProductRequestMailer).to receive(:send_email).and_return(true)
+
+      put :update, id: product_request.id
+
+      expect(ProductRequestMailer).to have_received(:send_email)
+    end
+  end
+
+  def product_request
+    @product_request ||= create(:product_request, :with_draft)
+  end
+
+  def admin
+    @admin ||= create(:user, :as_admin)
+  end
+end

--- a/spec/mailers/product_request_mailer_spec.rb
+++ b/spec/mailers/product_request_mailer_spec.rb
@@ -1,0 +1,18 @@
+require "rails_helper"
+
+describe ProductRequestMailer do
+  describe "#send_email" do
+    include ActionView::Helpers::UrlHelper
+    it "sends an email with the correct information" do
+      user = create(:user)
+      product = create(:product)
+      mail = described_class.send_email(product, user)
+
+      expect(mail.to).to include user.email
+      expect(mail.from).to include ENV.fetch("MAILER_FROM_EMAIL")
+      expect(mail.subject).to eq t("product_request_mailer.send_email.subject")
+      expect(mail.body).to include user.first_name
+      expect(mail.body).to include product.name
+    end
+  end
+end

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -24,6 +24,7 @@ module Features
 end
 
 RSpec.configure do |config|
+  config.include AuthenticationHelper, type: :controller
   config.include Features, type: :feature
   config.include Devise::TestHelpers, type: :controller
   config.include Paperclip::Shoulda::Matchers, type: :model

--- a/spec/support/helpers/authentication_helper.rb
+++ b/spec/support/helpers/authentication_helper.rb
@@ -1,0 +1,6 @@
+module AuthenticationHelper
+  def sign_in_user(user)
+    @request.env["devise.mapping"] = Devise.mappings[:user]
+    sign_in user
+  end
+end


### PR DESCRIPTION
Send an email to ProductOwners when their request to have editing rights over a Product has been approved.

* Send email when Admin approves ProductRequest belonging to ProductOwner