### PR TITLE
Add Organization Name to User

### DIFF
--- a/app/assets/stylesheets/extends/_modal.scss
+++ b/app/assets/stylesheets/extends/_modal.scss
@@ -42,7 +42,7 @@
       content: "\f00d";
       font-family: FontAwesome;
       line-height: 2em;
-      padding-left: 0.75em;
+      padding-left: 0.5em;
       vertical-align: center;
       text-align: right;
     }

--- a/app/assets/stylesheets/modules/_government_user_modal.scss
+++ b/app/assets/stylesheets/modules/_government_user_modal.scss
@@ -1,6 +1,12 @@
 .default-layout {
+
   .gov-user-sign-up {
-    top: 1em;
+    padding: 1.5em 2em;
+    top: 0.5em;
+
+    label {
+      font-size: 0.85em;
+    }
   }
 }
 
@@ -14,6 +20,25 @@
       @include animation-fill-mode(forwards);
       @include animation-delay(0.1s);
     }
+  }
+
+  h1 {
+    margin-left: auto;
+    margin-right: auto;
+    width: 75%;
+  }
+
+  input {
+
+    &.string {
+      font-size: 0.9em;
+      padding: 0.65em 0.75em;
+    }
+  }
+
+  select {
+    font-size: 0.9em;
+    padding: 0.65em 0.75em;
   }
 
   .loading {

--- a/app/controllers/government_users/registrations_controller.rb
+++ b/app/controllers/government_users/registrations_controller.rb
@@ -25,8 +25,14 @@ class GovernmentUsers::RegistrationsController < RegistrationsController
   end
 
   def sign_up_params
-    params.require(:government_user).
-      permit(:agency_id, :first_name, :last_name, :email, :password)
+    params.require(:government_user).permit(
+      :agency_id,
+      :email,
+      :first_name,
+      :last_name,
+      :organization_name,
+      :password
+    )
   end
 
   def user_has_gov_email?(email)

--- a/app/controllers/registrations_controller.rb
+++ b/app/controllers/registrations_controller.rb
@@ -17,6 +17,7 @@ class RegistrationsController < Devise::RegistrationsController
   end
 
   def sign_up_params
-    params.require(:user).permit(:first_name, :last_name, :email, :password)
+    params.require(:user).
+      permit(:email, :first_name, :last_name, :password)
   end
 end

--- a/app/views/government_users/registrations/_form.html.haml
+++ b/app/views/government_users/registrations/_form.html.haml
@@ -9,5 +9,8 @@
       required: true,
       hint: ("#{@minimum_password_length} characters minimum" if @minimum_password_length)
     = f.input :agency_id, collection: Agency.all
+    = f.input :organization_name,
+      required: true,
+      label: t(".organization_name_html")
   .form-actions
     = f.button :submit, "Sign up"

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -90,6 +90,8 @@ en:
     failures:
       no_gov_email: You must have a .gov or .mil email address to sign up.
     registrations:
+      form:
+        organization_name_html: Team Name <em>(your team within your agency)</em>
       new:
         heading: Sign up to start using the Apps.gov marketplace!
 

--- a/db/migrate/20160721140221_add_organization_name_to_user.rb
+++ b/db/migrate/20160721140221_add_organization_name_to_user.rb
@@ -1,0 +1,5 @@
+class AddOrganizationNameToUser < ActiveRecord::Migration
+  def change
+    add_column :users, :organization_name, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20160615164348) do
+ActiveRecord::Schema.define(version: 20160721140221) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -186,6 +186,7 @@ ActiveRecord::Schema.define(version: 20160615164348) do
     t.string   "confirmation_token"
     t.datetime "confirmed_at"
     t.datetime "confirmation_sent_at"
+    t.string   "organization_name"
   end
 
   add_index "users", ["agency_id"], name: "index_users_on_agency_id", using: :btree

--- a/spec/features/government_users/government_user_signs_up_spec.rb
+++ b/spec/features/government_users/government_user_signs_up_spec.rb
@@ -12,6 +12,7 @@ feature "A Government User signs up" do
       fill_in "Email", with: "email@email.gov"
       fill_in "Password", with: "12345sixsevenEight", match: :prefer_exact
       select(agency.name, from: "Agency")
+      fill_in "Team Name (your team within your agency)", with: "Team Name"
 
       click_on "Sign up"
 


### PR DESCRIPTION
Add a field for Users to specify their Organization/Team within an Agency on sign up.

* Add Organization Name to User
* Add organization name input to User sign up