### PR TITLE
ProductOwner Removes ProductRequest

### DIFF
--- a/app/assets/stylesheets/product_owners/_dashboard.scss
+++ b/app/assets/stylesheets/product_owners/_dashboard.scss
@@ -4,6 +4,10 @@
 
     a {
       color: $color-primary;
+
+      &.usa-button {
+        color: $white;
+      }
     }
 
     h2 {

--- a/app/assets/stylesheets/products/_show.scss
+++ b/app/assets/stylesheets/products/_show.scss
@@ -38,7 +38,6 @@
 
       &:hover {
         background-color: $color-primary;
-        color: $white;
         text-decoration: none;
       }
 

--- a/app/controllers/product_owners/product_requests_controller.rb
+++ b/app/controllers/product_owners/product_requests_controller.rb
@@ -13,6 +13,20 @@ module ProductOwners
       redirect_to product_path(@product_request.product)
     end
 
+    def destroy
+      @product_request = ProductRequest.find(params[:id])
+
+      if @product_request.destroy
+        flash[:success] =
+          I18n.t("product_owners.product_requests.destroy.success")
+      else
+        flash[:error] =
+          I18n.t("product_owners.product_requests.destroy.error")
+      end
+
+      redirect_to dashboard_path
+    end
+
     private
 
     def product_request_params

--- a/app/models/ability.rb
+++ b/app/models/ability.rb
@@ -10,10 +10,11 @@ class Ability
       can :create, ProductRequest
       can :read, Dashboard
     elsif user.type == "ProductOwner"
-      can :create, ProductRequest
       can :manage, Product do |product|
         product.product_requests.map(&:user_id).include? user.id
       end
+      can :create, ProductRequest
+      can :destroy, ProductRequest, user_id: user.id
       can :read, Dashboard
     else
       can :read, Product

--- a/app/views/product_owners/dashboard/_product_request.html.haml
+++ b/app/views/product_owners/dashboard/_product_request.html.haml
@@ -2,3 +2,8 @@
   %td
     = link_to product_request.product.name,
       product_path(product_request.product)
+  %td
+    = link_to t(".delete"),
+      product_owners_product_request_path(product_request),
+      data: {confirm: t(".confirm_destroy")},
+      method: :delete

--- a/app/views/product_owners/dashboard/_product_requests.html.haml
+++ b/app/views/product_owners/dashboard/_product_requests.html.haml
@@ -7,6 +7,8 @@
         %tr
           %th
             = t(".product_name")
+          %th
+            = t(".actions")
       %tbody
         = render partial: "product_request", collection: product_requests
   - else

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -129,7 +129,11 @@ en:
         no_products:
           No products have been approved for you to edit yet.
         product_name: Product Name
+      product_request:
+        confirm_destroy: Are you sure you want to remove this request?
+        delete: Remove
       product_requests:
+        actions: Actions
         heading: Requested Products
         no_requests: You have no outstanding Product Requests.
         product_name: Product Name
@@ -138,6 +142,9 @@ en:
       create:
         failure: Something went wrong. Please try again.
         success: Your request to edit this Product has been created.
+      destroy:
+        error: Something went wrong. Please try again.
+        success: Your Product Request was deleted.
     products:
       edit:
         header: Edit Product

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -21,7 +21,7 @@ Rails.application.routes.draw do
   end
 
   namespace :product_owners do
-    resources :product_requests, only: [:new, :create]
+    resources :product_requests, only: [:new, :create, :destroy]
     resources :products, only: [:edit, :update]
   end
 

--- a/spec/features/product_owners/product_owner_creates_an_account_spec.rb
+++ b/spec/features/product_owners/product_owner_creates_an_account_spec.rb
@@ -15,7 +15,7 @@ feature "Product Owner creates an Account" do
       click_on "Sign up"
 
       expect(page).
-        to have_text t("devise.registrations.signed_up")
+        to have_text t("modules.navigation.dashboard")
     end
   end
 
@@ -33,7 +33,7 @@ feature "Product Owner creates an Account" do
       click_on "Sign up"
 
       expect(page).
-        to have_text t("devise.registrations.signed_up")
+        to have_text t("modules.navigation.dashboard")
     end
   end
 

--- a/spec/features/product_owners/product_owner_removes_product_request_spec.rb
+++ b/spec/features/product_owners/product_owner_removes_product_request_spec.rb
@@ -1,0 +1,23 @@
+require "rails_helper"
+
+feature "Product Owner Destroys Product Request", js: true do
+  before { login_as(product_owner, scope: :product_owner) }
+
+  scenario "by clicking the Remove link in their Dashboard" do
+    create(:product_request, product: product, user: product_owner)
+    visit dashboard_path
+
+    click_on t("product_owners.dashboard.product_request.delete")
+
+    expect(page).
+      to have_text t("product_owners.product_requests.destroy.success")
+  end
+
+  def product
+    @product ||= create(:product)
+  end
+
+  def product_owner
+    @product_owner ||= create(:user, :as_product_owner)
+  end
+end

--- a/spec/features/users/user_sign_in_spec.rb
+++ b/spec/features/users/user_sign_in_spec.rb
@@ -14,7 +14,7 @@ feature "User Sign In" do
 
       click_on t("devise.sessions.form.sign_in")
 
-      expect(page).to have_text "Signed in successfully"
+      expect(page).to have_text t("modules.navigation.dashboard")
     end
   end
 
@@ -31,7 +31,7 @@ feature "User Sign In" do
       within("div#sign-in-modal") do
         click_on t("devise.sessions.form.sign_in")
       end
-      expect(page).to have_text t("devise.sessions.signed_in")
+      expect(page).to have_text t("modules.navigation.dashboard")
     end
   end
 


### PR DESCRIPTION
Enables ProductOwners to cancel ProductRequests from their Dashboard.

* Add destroy action for ProductRequest in ProductOwner ProductRequest controller
* Add destroy link to each ProductReuqest in the ProductOwner Dashboard