### PR TITLE
Limit Algolia Product Info

### DIFF
--- a/.sample.env
+++ b/.sample.env
@@ -1,6 +1,7 @@
 # http://ddollar.github.com/foreman/
 ALGOLIA_API_KEY=7654321
 ALGOLIA_APP_ID=123456
+ALGOLIA_SEARCH_API_KEY=123456
 ASSET_HOST=localhost:3000
 HOST=localhost:3000
 RACK_ENV=development

--- a/app/models/product.rb
+++ b/app/models/product.rb
@@ -39,7 +39,7 @@ class Product < ActiveRecord::Base
   validates_attachment_content_type :logo, content_type: %r{\Aimage\/.*\Z}
 
   algoliasearch enqueue: :trigger_delayed_job, sanitize: true do
-    add_attribute :logo_url
+    attribute :name, :logo_url, :short_description, :slug
   end
 
   def self.most_popular


### PR DESCRIPTION
Explicitly define attributes sent to Algolia for Products. Also updates the sample.env to include ALGOLIA_SEARCH_API_KEY.

* Explicitly define Product attributes sent to Algolia
* Add ALGOLIA_SEARCH_API_KEY to sample.env