### PR TITLE
Display Product ATO Types in Product Page

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,5 +12,6 @@ manifest.yml
 /log/*
 /public/system
 /public/assets
+/public/sitemap.xml
 /tags
 /tmp/*

--- a/app/assets/stylesheets/base/_variables.scss
+++ b/app/assets/stylesheets/base/_variables.scss
@@ -29,7 +29,7 @@ $color-gray-dark: #323a45;
 
 // Font Colors
 $base-background-color: #f9f9f9;
-$base-font-color: $dark-gray;
+$base-font-color: $color-gray-dark;
 $action-color: $blue;
 
 // Border

--- a/app/assets/stylesheets/products/_index.scss
+++ b/app/assets/stylesheets/products/_index.scss
@@ -1,11 +1,14 @@
 .aa-suggestion {
+
   &:first-child {
+
     .hit-auto-complete {
       border-radius: 0.2em 0.2em 0 0;
     }
   }
 
   &:last-child {
+
     .hit-auto-complete {
       border-radius: 0 0 0.2em 0.2em;
     }

--- a/app/assets/stylesheets/products/_show.scss
+++ b/app/assets/stylesheets/products/_show.scss
@@ -15,6 +15,60 @@
 
 .products-show {
 
+  .checked,
+  .unchecked {
+
+    li {
+      margin: 0.2em 0;
+
+      &::before {
+        display: inline-block;
+        font-family: FontAwesome;
+        font-style: normal;
+        font-weight: normal;
+        text-decoration: inherit;
+      }
+    }
+  }
+
+  .checked {
+    margin-bottom: 0;
+
+    a {
+      color: $color-gray-dark;
+
+      &:hover {
+        color: $color-primary;
+        text-decoration: none;
+      }
+    }
+
+    i {
+      font-size: 0.75em;
+    }
+
+    li {
+
+      &::before {
+        color: $color-primary;
+        content: "\f058";
+      }
+    }
+  }
+
+  .column-container {
+    margin-top: 1em;
+  }
+
+  .product-ato-types {
+    @include span-columns(6);
+
+    h3 {
+      font-size: 1.1em;
+      margin-bottom: 0.5em;
+    }
+  }
+
   .product-content {
     @include span-columns(9);
     @include omega;
@@ -101,6 +155,18 @@
       @include animation-fill-mode(forwards);
       opacity: 0;
       visibility: hidden;
+    }
+  }
+
+  .unchecked {
+    color: $medium-gray;
+    margin-top: 0;
+
+    li {
+
+      &::before {
+        content: "\f10c";
+      }
     }
   }
 

--- a/app/controllers/products_controller.rb
+++ b/app/controllers/products_controller.rb
@@ -1,11 +1,10 @@
 class ProductsController < ApplicationController
   def index
-    @products = ProductPresenter.new
+    @products = ProductsPresenter.new
   end
 
   def show
-    @product = Product.find(params[:id])
-    @product_request = @product.product_requests.new
+    @product_presenter = ProductPresenter.new(params[:id])
   end
 
   def search

--- a/app/presenters/product_presenter.rb
+++ b/app/presenters/product_presenter.rb
@@ -1,13 +1,25 @@
 class ProductPresenter
-  def categories
-    Category.all.order(:name)
+  def initialize(product_id)
+    @product_id = product_id
   end
 
-  def most_popular
-    Product.most_popular
+  def new_product_request
+    product.product_requests.new
   end
 
-  def newest
-    Product.all.order("created_at DESC").limit(3)
+  def product
+    @product = Product.find(@product_id)
+  end
+
+  def product_ato_types
+    @product_ato_types ||= product.ato_types
+  end
+
+  def product_ato_statuses
+    @product_ato_statuses ||= product.ato_statuses
+  end
+
+  def remaining_ato_types
+    AtoType.where.not(id: product_ato_types.select(:id))
   end
 end

--- a/app/presenters/products_presenter.rb
+++ b/app/presenters/products_presenter.rb
@@ -1,0 +1,13 @@
+class ProductsPresenter
+  def categories
+    Category.all.order(:name)
+  end
+
+  def most_popular
+    Product.most_popular
+  end
+
+  def newest
+    Product.all.order("created_at DESC").limit(3)
+  end
+end

--- a/app/views/products/_ato_status.html.haml
+++ b/app/views/products/_ato_status.html.haml
@@ -1,0 +1,7 @@
+= content_tag_for :li, ato_status do
+  - if ato_status.url
+    = link_to ato_status.url, target: "_blank" do
+      = ato_status.ato_type.name
+      %i.fa.fa-external-link
+  - else
+    = ato_status.ato_type.name

--- a/app/views/products/_ato_type.html.haml
+++ b/app/views/products/_ato_type.html.haml
@@ -1,0 +1,2 @@
+= content_tag_for :li, ato_type do
+  = ato_type.name

--- a/app/views/products/_ato_types.html.haml
+++ b/app/views/products/_ato_types.html.haml
@@ -1,0 +1,6 @@
+%h3
+  = t(".heading")
+%ul.checked
+  = render partial: "ato_status", collection: product_presenter.product_ato_statuses
+%ul.unchecked
+  = render partial: "ato_type", collection: product_presenter.remaining_ato_types

--- a/app/views/products/_product_content.html.haml
+++ b/app/views/products/_product_content.html.haml
@@ -1,16 +1,16 @@
 %header.product-header
   %h1.product-name
-    = link_to "//#{product.url}", target: "_blank" do
-      = product.name
+    = link_to "//#{product_presenter.product.url}", target: "_blank" do
+      = product_presenter.product.name
       %i.fa.fa-external-link
   - if no_users_signed_in? || product_owner_signed_in?
     .product-edit
-      = simple_form_for [:product_owners, product_request] do |f|
-        = f.input :product_id, value: product.id, as: :hidden
+      = simple_form_for [:product_owners, product_presenter.new_product_request] do |f|
+        = f.input :product_id, value: product_presenter.product.id, as: :hidden
         - if no_users_signed_in?
           = button_tag(class: "modal-trigger", data: {modal_id: "product-owner-signup-modal"}, id: "edit-product-button", type: "submit") do
             = t(".edit_product_html")
-        - elsif product_belongs_to_user?(product)
+        - elsif product_belongs_to_user?(product_presenter.product)
           = link_to product_owner_dashboard_path, class: "requested" do
             %i.fa.fa-check
             = t(".requested")
@@ -18,5 +18,7 @@
           = button_tag(id: "edit-product-button", type: "submit") do
             = t(".edit_product_html")
 .product-info
-  = product.long_description
-
+  = product_presenter.product.long_description
+.column-container
+  .product-ato-types
+    = render "ato_types", product_presenter: product_presenter

--- a/app/views/products/show.html.haml
+++ b/app/views/products/show.html.haml
@@ -2,16 +2,15 @@
   .product-nav.breadcrumbs
     = link_to t(".products"), root_path
     %i.fa.fa-caret-right
-    = @product.name
+    = @product_presenter.product.name
 
   %aside.product-sidebar
     = render "product_sidebar",
-      product: @product,
-      product_request: @product_request
+      product: @product_presenter.product,
+      product_request: @product_presenter.new_product_request
   %section.product-content
     = render "product_content",
-      product: @product,
-      product_request: @product_request
+      product_presenter: @product_presenter
 
 
 - unless signed_in?

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -185,6 +185,8 @@ en:
       success: Product Requested!
 
   products:
+    ato_types:
+      heading: Authority to Operate (ATO)
     index:
       categories: Categories
       header: Discover Your Team’s Next Favorite App

--- a/public/sitemap.xml
+++ b/public/sitemap.xml
@@ -1,585 +1,585 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
   <url>
-    <loc>http://localhost:7000/</loc>
+    <loc>http://localhost:4000/</loc>
     <priority>1</priority>
   </url>
   <url>
-    <loc>http://localhost:7000/products/search</loc>
+    <loc>http://localhost:4000/products/search</loc>
   </url>
   <url>
-    <loc>http://localhost:7000/products</loc>
+    <loc>http://localhost:4000/products</loc>
   </url>
   <url>
-    <loc>http://localhost:7000/products/acquia</loc>
-    <lastmod>2016-06-14</lastmod>
+    <loc>http://localhost:4000/products/acquia</loc>
+    <lastmod>2016-08-02</lastmod>
   </url>
   <url>
-    <loc>http://localhost:7000/products/addthis</loc>
-    <lastmod>2016-06-14</lastmod>
+    <loc>http://localhost:4000/products/addthis</loc>
+    <lastmod>2016-08-02</lastmod>
   </url>
   <url>
-    <loc>http://localhost:7000/products/adobe-connect-govcloud</loc>
-    <lastmod>2016-06-14</lastmod>
+    <loc>http://localhost:4000/products/adobe-connect-govcloud</loc>
+    <lastmod>2016-08-02</lastmod>
   </url>
   <url>
-    <loc>http://localhost:7000/products/adobe-connect-us-ew</loc>
-    <lastmod>2016-06-14</lastmod>
+    <loc>http://localhost:4000/products/adobe-connect-us-ew</loc>
+    <lastmod>2016-08-02</lastmod>
   </url>
   <url>
-    <loc>http://localhost:7000/products/adobe-exp-govcloud</loc>
-    <lastmod>2016-06-14</lastmod>
+    <loc>http://localhost:4000/products/adobe-exp-govcloud</loc>
+    <lastmod>2016-08-02</lastmod>
   </url>
   <url>
-    <loc>http://localhost:7000/products/adobe-exp-us-ew</loc>
-    <lastmod>2016-06-14</lastmod>
+    <loc>http://localhost:4000/products/adobe-exp-us-ew</loc>
+    <lastmod>2016-08-02</lastmod>
   </url>
   <url>
-    <loc>http://localhost:7000/products/adobe-live-govcloud</loc>
-    <lastmod>2016-06-14</lastmod>
+    <loc>http://localhost:4000/products/adobe-live-govcloud</loc>
+    <lastmod>2016-08-02</lastmod>
   </url>
   <url>
-    <loc>http://localhost:7000/products/adobe-live-us-ew</loc>
-    <lastmod>2016-06-14</lastmod>
+    <loc>http://localhost:4000/products/adobe-live-us-ew</loc>
+    <lastmod>2016-08-02</lastmod>
   </url>
   <url>
-    <loc>http://localhost:7000/products/ains</loc>
-    <lastmod>2016-06-14</lastmod>
+    <loc>http://localhost:4000/products/ains</loc>
+    <lastmod>2016-08-02</lastmod>
   </url>
   <url>
-    <loc>http://localhost:7000/products/akamai-technologies</loc>
-    <lastmod>2016-06-14</lastmod>
+    <loc>http://localhost:4000/products/akamai-technologies</loc>
+    <lastmod>2016-08-02</lastmod>
   </url>
   <url>
-    <loc>http://localhost:7000/products/amazon-web-services-ew-public</loc>
-    <lastmod>2016-06-14</lastmod>
+    <loc>http://localhost:4000/products/amazon-web-services-ew-public</loc>
+    <lastmod>2016-08-02</lastmod>
   </url>
   <url>
-    <loc>http://localhost:7000/products/amazon-web-services-gov</loc>
-    <lastmod>2016-06-14</lastmod>
+    <loc>http://localhost:4000/products/amazon-web-services-gov</loc>
+    <lastmod>2016-08-02</lastmod>
   </url>
   <url>
-    <loc>http://localhost:7000/products/appian</loc>
-    <lastmod>2016-06-14</lastmod>
+    <loc>http://localhost:4000/products/appian</loc>
+    <lastmod>2016-08-02</lastmod>
   </url>
   <url>
-    <loc>http://localhost:7000/products/arc-p</loc>
-    <lastmod>2016-06-14</lastmod>
+    <loc>http://localhost:4000/products/arc-p</loc>
+    <lastmod>2016-08-02</lastmod>
   </url>
   <url>
-    <loc>http://localhost:7000/products/arcanum-group-inc</loc>
-    <lastmod>2016-06-14</lastmod>
+    <loc>http://localhost:4000/products/arcanum-group-inc</loc>
+    <lastmod>2016-08-02</lastmod>
   </url>
   <url>
-    <loc>http://localhost:7000/products/arcwrx</loc>
-    <lastmod>2016-06-14</lastmod>
+    <loc>http://localhost:4000/products/arcwrx</loc>
+    <lastmod>2016-08-02</lastmod>
   </url>
   <url>
-    <loc>http://localhost:7000/products/asana</loc>
-    <lastmod>2016-06-14</lastmod>
+    <loc>http://localhost:4000/products/asana</loc>
+    <lastmod>2016-08-02</lastmod>
   </url>
   <url>
-    <loc>http://localhost:7000/products/athoc</loc>
-    <lastmod>2016-06-14</lastmod>
+    <loc>http://localhost:4000/products/athoc</loc>
+    <lastmod>2016-08-02</lastmod>
   </url>
   <url>
-    <loc>http://localhost:7000/products/att-cloud</loc>
-    <lastmod>2016-06-14</lastmod>
+    <loc>http://localhost:4000/products/att-cloud</loc>
+    <lastmod>2016-08-02</lastmod>
   </url>
   <url>
-    <loc>http://localhost:7000/products/att-storage</loc>
-    <lastmod>2016-06-14</lastmod>
+    <loc>http://localhost:4000/products/att-storage</loc>
+    <lastmod>2016-08-02</lastmod>
   </url>
   <url>
-    <loc>http://localhost:7000/products/autodesk-bim</loc>
-    <lastmod>2016-06-14</lastmod>
+    <loc>http://localhost:4000/products/autodesk-bim</loc>
+    <lastmod>2016-08-02</lastmod>
   </url>
   <url>
-    <loc>http://localhost:7000/products/autodesk-cloud</loc>
-    <lastmod>2016-06-14</lastmod>
+    <loc>http://localhost:4000/products/autodesk-cloud</loc>
+    <lastmod>2016-08-02</lastmod>
   </url>
   <url>
-    <loc>http://localhost:7000/products/avue-technologies-corporation</loc>
-    <lastmod>2016-06-14</lastmod>
+    <loc>http://localhost:4000/products/avue-technologies-corporation</loc>
+    <lastmod>2016-08-02</lastmod>
   </url>
   <url>
-    <loc>http://localhost:7000/products/bitly</loc>
-    <lastmod>2016-06-14</lastmod>
+    <loc>http://localhost:4000/products/bitly</loc>
+    <lastmod>2016-08-02</lastmod>
   </url>
   <url>
-    <loc>http://localhost:7000/products/blackboard</loc>
-    <lastmod>2016-06-14</lastmod>
+    <loc>http://localhost:4000/products/blackboard</loc>
+    <lastmod>2016-08-02</lastmod>
   </url>
   <url>
-    <loc>http://localhost:7000/products/blackmesh</loc>
-    <lastmod>2016-06-14</lastmod>
+    <loc>http://localhost:4000/products/blackmesh</loc>
+    <lastmod>2016-08-02</lastmod>
   </url>
   <url>
-    <loc>http://localhost:7000/products/bmc-software</loc>
-    <lastmod>2016-06-14</lastmod>
+    <loc>http://localhost:4000/products/bmc-software</loc>
+    <lastmod>2016-08-02</lastmod>
   </url>
   <url>
-    <loc>http://localhost:7000/products/box</loc>
-    <lastmod>2016-06-14</lastmod>
+    <loc>http://localhost:4000/products/box</loc>
+    <lastmod>2016-08-02</lastmod>
   </url>
   <url>
-    <loc>http://localhost:7000/products/cartodb</loc>
-    <lastmod>2016-06-14</lastmod>
+    <loc>http://localhost:4000/products/cartodb</loc>
+    <lastmod>2016-08-02</lastmod>
   </url>
   <url>
-    <loc>http://localhost:7000/products/centrify</loc>
-    <lastmod>2016-06-14</lastmod>
+    <loc>http://localhost:4000/products/centrify</loc>
+    <lastmod>2016-08-02</lastmod>
   </url>
   <url>
-    <loc>http://localhost:7000/products/cgi</loc>
-    <lastmod>2016-06-14</lastmod>
+    <loc>http://localhost:4000/products/cgi</loc>
+    <lastmod>2016-08-02</lastmod>
   </url>
   <url>
-    <loc>http://localhost:7000/products/cisco</loc>
-    <lastmod>2016-06-14</lastmod>
+    <loc>http://localhost:4000/products/cisco</loc>
+    <lastmod>2016-08-02</lastmod>
   </url>
   <url>
-    <loc>http://localhost:7000/products/clear-government-solutions</loc>
-    <lastmod>2016-06-14</lastmod>
+    <loc>http://localhost:4000/products/clear-government-solutions</loc>
+    <lastmod>2016-08-02</lastmod>
   </url>
   <url>
-    <loc>http://localhost:7000/products/cludo</loc>
-    <lastmod>2016-06-14</lastmod>
+    <loc>http://localhost:4000/products/cludo</loc>
+    <lastmod>2016-08-02</lastmod>
   </url>
   <url>
-    <loc>http://localhost:7000/products/collab9</loc>
-    <lastmod>2016-06-14</lastmod>
+    <loc>http://localhost:4000/products/collab9</loc>
+    <lastmod>2016-08-02</lastmod>
   </url>
   <url>
-    <loc>http://localhost:7000/products/complete-discovery-source</loc>
-    <lastmod>2016-06-14</lastmod>
+    <loc>http://localhost:4000/products/complete-discovery-source</loc>
+    <lastmod>2016-08-02</lastmod>
   </url>
   <url>
-    <loc>http://localhost:7000/products/compusearch</loc>
-    <lastmod>2016-06-14</lastmod>
+    <loc>http://localhost:4000/products/compusearch</loc>
+    <lastmod>2016-08-02</lastmod>
   </url>
   <url>
-    <loc>http://localhost:7000/products/concurrent-technologies-corporation</loc>
-    <lastmod>2016-06-14</lastmod>
+    <loc>http://localhost:4000/products/concurrent-technologies-corporation</loc>
+    <lastmod>2016-08-02</lastmod>
   </url>
   <url>
-    <loc>http://localhost:7000/products/connectsolutions</loc>
-    <lastmod>2016-06-14</lastmod>
+    <loc>http://localhost:4000/products/connectsolutions</loc>
+    <lastmod>2016-08-02</lastmod>
   </url>
   <url>
-    <loc>http://localhost:7000/products/cornerstone-ondemand</loc>
-    <lastmod>2016-06-14</lastmod>
+    <loc>http://localhost:4000/products/cornerstone-ondemand</loc>
+    <lastmod>2016-08-02</lastmod>
   </url>
   <url>
-    <loc>http://localhost:7000/products/coupa</loc>
-    <lastmod>2016-06-14</lastmod>
+    <loc>http://localhost:4000/products/coupa</loc>
+    <lastmod>2016-08-02</lastmod>
   </url>
   <url>
-    <loc>http://localhost:7000/products/crowdkeep-expense</loc>
-    <lastmod>2016-06-14</lastmod>
+    <loc>http://localhost:4000/products/crowdkeep-expense</loc>
+    <lastmod>2016-08-02</lastmod>
   </url>
   <url>
-    <loc>http://localhost:7000/products/crowdkeep-time</loc>
-    <lastmod>2016-06-14</lastmod>
+    <loc>http://localhost:4000/products/crowdkeep-time</loc>
+    <lastmod>2016-08-02</lastmod>
   </url>
   <url>
-    <loc>http://localhost:7000/products/csc</loc>
-    <lastmod>2016-06-14</lastmod>
+    <loc>http://localhost:4000/products/csc</loc>
+    <lastmod>2016-08-02</lastmod>
   </url>
   <url>
-    <loc>http://localhost:7000/products/cyfe</loc>
-    <lastmod>2016-06-14</lastmod>
+    <loc>http://localhost:4000/products/cyfe</loc>
+    <lastmod>2016-08-02</lastmod>
   </url>
   <url>
-    <loc>http://localhost:7000/products/datapipe</loc>
-    <lastmod>2016-06-14</lastmod>
+    <loc>http://localhost:4000/products/datapipe</loc>
+    <lastmod>2016-08-02</lastmod>
   </url>
   <url>
-    <loc>http://localhost:7000/products/decision-lens</loc>
-    <lastmod>2016-06-14</lastmod>
+    <loc>http://localhost:4000/products/decision-lens</loc>
+    <lastmod>2016-08-02</lastmod>
   </url>
   <url>
-    <loc>http://localhost:7000/products/dell</loc>
-    <lastmod>2016-06-14</lastmod>
+    <loc>http://localhost:4000/products/dell</loc>
+    <lastmod>2016-08-02</lastmod>
   </url>
   <url>
-    <loc>http://localhost:7000/products/dialogue-app</loc>
-    <lastmod>2016-06-14</lastmod>
+    <loc>http://localhost:4000/products/dialogue-app</loc>
+    <lastmod>2016-08-02</lastmod>
   </url>
   <url>
-    <loc>http://localhost:7000/products/dipity</loc>
-    <lastmod>2016-06-14</lastmod>
+    <loc>http://localhost:4000/products/dipity</loc>
+    <lastmod>2016-08-02</lastmod>
   </url>
   <url>
-    <loc>http://localhost:7000/products/dot-workplace</loc>
-    <lastmod>2016-06-14</lastmod>
+    <loc>http://localhost:4000/products/dot-workplace</loc>
+    <lastmod>2016-08-02</lastmod>
   </url>
   <url>
-    <loc>http://localhost:7000/products/economic-systems-inc</loc>
-    <lastmod>2016-06-14</lastmod>
+    <loc>http://localhost:4000/products/economic-systems-inc</loc>
+    <lastmod>2016-08-02</lastmod>
   </url>
   <url>
-    <loc>http://localhost:7000/products/edge-hosting</loc>
-    <lastmod>2016-06-14</lastmod>
+    <loc>http://localhost:4000/products/edge-hosting</loc>
+    <lastmod>2016-08-02</lastmod>
   </url>
   <url>
-    <loc>http://localhost:7000/products/esri</loc>
-    <lastmod>2016-06-14</lastmod>
+    <loc>http://localhost:4000/products/esri</loc>
+    <lastmod>2016-08-02</lastmod>
   </url>
   <url>
-    <loc>http://localhost:7000/products/eventbrite</loc>
-    <lastmod>2016-06-14</lastmod>
+    <loc>http://localhost:4000/products/eventbrite</loc>
+    <lastmod>2016-08-02</lastmod>
   </url>
   <url>
-    <loc>http://localhost:7000/products/everbridge</loc>
-    <lastmod>2016-06-14</lastmod>
+    <loc>http://localhost:4000/products/everbridge</loc>
+    <lastmod>2016-08-02</lastmod>
   </url>
   <url>
-    <loc>http://localhost:7000/products/fireeye</loc>
-    <lastmod>2016-06-14</lastmod>
+    <loc>http://localhost:4000/products/fireeye</loc>
+    <lastmod>2016-08-02</lastmod>
   </url>
   <url>
-    <loc>http://localhost:7000/products/flickr</loc>
-    <lastmod>2016-06-14</lastmod>
+    <loc>http://localhost:4000/products/flickr</loc>
+    <lastmod>2016-08-02</lastmod>
   </url>
   <url>
-    <loc>http://localhost:7000/products/general-dynamics-information-technology</loc>
-    <lastmod>2016-06-14</lastmod>
+    <loc>http://localhost:4000/products/general-dynamics-information-technology</loc>
+    <lastmod>2016-08-02</lastmod>
   </url>
   <url>
-    <loc>http://localhost:7000/products/github</loc>
-    <lastmod>2016-06-14</lastmod>
+    <loc>http://localhost:4000/products/github</loc>
+    <lastmod>2016-08-02</lastmod>
   </url>
   <url>
-    <loc>http://localhost:7000/products/google</loc>
-    <lastmod>2016-06-14</lastmod>
+    <loc>http://localhost:4000/products/google</loc>
+    <lastmod>2016-08-02</lastmod>
   </url>
   <url>
-    <loc>http://localhost:7000/products/govdelivery</loc>
-    <lastmod>2016-06-14</lastmod>
+    <loc>http://localhost:4000/products/govdelivery</loc>
+    <lastmod>2016-08-02</lastmod>
   </url>
   <url>
-    <loc>http://localhost:7000/products/group-in3sight</loc>
-    <lastmod>2016-06-14</lastmod>
+    <loc>http://localhost:4000/products/group-in3sight</loc>
+    <lastmod>2016-08-02</lastmod>
   </url>
   <url>
-    <loc>http://localhost:7000/products/hackpad</loc>
-    <lastmod>2016-06-14</lastmod>
+    <loc>http://localhost:4000/products/hackpad</loc>
+    <lastmod>2016-08-02</lastmod>
   </url>
   <url>
-    <loc>http://localhost:7000/products/hootsuite</loc>
-    <lastmod>2016-06-14</lastmod>
+    <loc>http://localhost:4000/products/hootsuite</loc>
+    <lastmod>2016-08-02</lastmod>
   </url>
   <url>
-    <loc>http://localhost:7000/products/hpe-fod</loc>
-    <lastmod>2016-06-14</lastmod>
+    <loc>http://localhost:4000/products/hpe-fod</loc>
+    <lastmod>2016-08-02</lastmod>
   </url>
   <url>
-    <loc>http://localhost:7000/products/hpe-helion</loc>
-    <lastmod>2016-06-14</lastmod>
+    <loc>http://localhost:4000/products/hpe-helion</loc>
+    <lastmod>2016-08-02</lastmod>
   </url>
   <url>
-    <loc>http://localhost:7000/products/huddle</loc>
-    <lastmod>2016-06-14</lastmod>
+    <loc>http://localhost:4000/products/huddle</loc>
+    <lastmod>2016-08-02</lastmod>
   </url>
   <url>
-    <loc>http://localhost:7000/products/ibm-cloud-dod</loc>
-    <lastmod>2016-06-14</lastmod>
+    <loc>http://localhost:4000/products/ibm-cloud-dod</loc>
+    <lastmod>2016-08-02</lastmod>
   </url>
   <url>
-    <loc>http://localhost:7000/products/ibm-maas360</loc>
-    <lastmod>2016-06-14</lastmod>
+    <loc>http://localhost:4000/products/ibm-maas360</loc>
+    <lastmod>2016-08-02</lastmod>
   </url>
   <url>
-    <loc>http://localhost:7000/products/ibm-smartcloud</loc>
-    <lastmod>2016-06-14</lastmod>
+    <loc>http://localhost:4000/products/ibm-smartcloud</loc>
+    <lastmod>2016-08-02</lastmod>
   </url>
   <url>
-    <loc>http://localhost:7000/products/ideascale</loc>
-    <lastmod>2016-06-14</lastmod>
+    <loc>http://localhost:4000/products/ideascale</loc>
+    <lastmod>2016-08-02</lastmod>
   </url>
   <url>
-    <loc>http://localhost:7000/products/ifttt</loc>
-    <lastmod>2016-06-14</lastmod>
+    <loc>http://localhost:4000/products/ifttt</loc>
+    <lastmod>2016-08-02</lastmod>
   </url>
   <url>
-    <loc>http://localhost:7000/products/isite</loc>
-    <lastmod>2016-06-14</lastmod>
+    <loc>http://localhost:4000/products/isite</loc>
+    <lastmod>2016-08-02</lastmod>
   </url>
   <url>
-    <loc>http://localhost:7000/products/itcnp</loc>
-    <lastmod>2016-06-14</lastmod>
+    <loc>http://localhost:4000/products/itcnp</loc>
+    <lastmod>2016-08-02</lastmod>
   </url>
   <url>
-    <loc>http://localhost:7000/products/knight-point-systems</loc>
-    <lastmod>2016-06-14</lastmod>
+    <loc>http://localhost:4000/products/knight-point-systems</loc>
+    <lastmod>2016-08-02</lastmod>
   </url>
   <url>
-    <loc>http://localhost:7000/products/lockheed-martin</loc>
-    <lastmod>2016-06-14</lastmod>
+    <loc>http://localhost:4000/products/lockheed-martin</loc>
+    <lastmod>2016-08-02</lastmod>
   </url>
   <url>
-    <loc>http://localhost:7000/products/mandrill</loc>
-    <lastmod>2016-06-14</lastmod>
+    <loc>http://localhost:4000/products/mandrill</loc>
+    <lastmod>2016-08-02</lastmod>
   </url>
   <url>
-    <loc>http://localhost:7000/products/mapbox</loc>
-    <lastmod>2016-06-14</lastmod>
+    <loc>http://localhost:4000/products/mapbox</loc>
+    <lastmod>2016-08-02</lastmod>
   </url>
   <url>
-    <loc>http://localhost:7000/products/max-general</loc>
-    <lastmod>2016-06-14</lastmod>
+    <loc>http://localhost:4000/products/max-general</loc>
+    <lastmod>2016-08-02</lastmod>
   </url>
   <url>
-    <loc>http://localhost:7000/products/max-shared</loc>
-    <lastmod>2016-06-14</lastmod>
+    <loc>http://localhost:4000/products/max-shared</loc>
+    <lastmod>2016-08-02</lastmod>
   </url>
   <url>
-    <loc>http://localhost:7000/products/measured-voice</loc>
-    <lastmod>2016-06-14</lastmod>
+    <loc>http://localhost:4000/products/measured-voice</loc>
+    <lastmod>2016-08-02</lastmod>
   </url>
   <url>
-    <loc>http://localhost:7000/products/meetup</loc>
-    <lastmod>2016-06-14</lastmod>
+    <loc>http://localhost:4000/products/meetup</loc>
+    <lastmod>2016-08-02</lastmod>
   </url>
   <url>
-    <loc>http://localhost:7000/products/micropact</loc>
-    <lastmod>2016-06-14</lastmod>
+    <loc>http://localhost:4000/products/micropact</loc>
+    <lastmod>2016-08-02</lastmod>
   </url>
   <url>
-    <loc>http://localhost:7000/products/microsoft-azure</loc>
-    <lastmod>2016-06-14</lastmod>
+    <loc>http://localhost:4000/products/microsoft-azure</loc>
+    <lastmod>2016-08-02</lastmod>
   </url>
   <url>
-    <loc>http://localhost:7000/products/microsoft-cloud</loc>
-    <lastmod>2016-06-14</lastmod>
+    <loc>http://localhost:4000/products/microsoft-cloud</loc>
+    <lastmod>2016-08-02</lastmod>
   </url>
   <url>
-    <loc>http://localhost:7000/products/microsoft-dynamics</loc>
-    <lastmod>2016-06-14</lastmod>
+    <loc>http://localhost:4000/products/microsoft-dynamics</loc>
+    <lastmod>2016-08-02</lastmod>
   </url>
   <url>
-    <loc>http://localhost:7000/products/microsoft-itar</loc>
-    <lastmod>2016-06-14</lastmod>
+    <loc>http://localhost:4000/products/microsoft-itar</loc>
+    <lastmod>2016-08-02</lastmod>
   </url>
   <url>
-    <loc>http://localhost:7000/products/microsoft-office</loc>
-    <lastmod>2016-06-14</lastmod>
+    <loc>http://localhost:4000/products/microsoft-office</loc>
+    <lastmod>2016-08-02</lastmod>
   </url>
   <url>
-    <loc>http://localhost:7000/products/microsoft-parature</loc>
-    <lastmod>2016-06-14</lastmod>
+    <loc>http://localhost:4000/products/microsoft-parature</loc>
+    <lastmod>2016-08-02</lastmod>
   </url>
   <url>
-    <loc>http://localhost:7000/products/mobileiron</loc>
-    <lastmod>2016-06-14</lastmod>
+    <loc>http://localhost:4000/products/mobileiron</loc>
+    <lastmod>2016-08-02</lastmod>
   </url>
   <url>
-    <loc>http://localhost:7000/products/netcomm-inc</loc>
-    <lastmod>2016-06-14</lastmod>
+    <loc>http://localhost:4000/products/netcomm-inc</loc>
+    <lastmod>2016-08-02</lastmod>
   </url>
   <url>
-    <loc>http://localhost:7000/products/okta</loc>
-    <lastmod>2016-06-14</lastmod>
+    <loc>http://localhost:4000/products/okta</loc>
+    <lastmod>2016-08-02</lastmod>
   </url>
   <url>
-    <loc>http://localhost:7000/products/onwire</loc>
-    <lastmod>2016-06-14</lastmod>
+    <loc>http://localhost:4000/products/onwire</loc>
+    <lastmod>2016-08-02</lastmod>
   </url>
   <url>
-    <loc>http://localhost:7000/products/opencalais</loc>
-    <lastmod>2016-06-14</lastmod>
+    <loc>http://localhost:4000/products/opencalais</loc>
+    <lastmod>2016-08-02</lastmod>
   </url>
   <url>
-    <loc>http://localhost:7000/products/oracle-fed-cloud</loc>
-    <lastmod>2016-06-14</lastmod>
+    <loc>http://localhost:4000/products/oracle-fed-cloud</loc>
+    <lastmod>2016-08-02</lastmod>
   </url>
   <url>
-    <loc>http://localhost:7000/products/oracle-govcloud</loc>
-    <lastmod>2016-06-14</lastmod>
+    <loc>http://localhost:4000/products/oracle-govcloud</loc>
+    <lastmod>2016-08-02</lastmod>
   </url>
   <url>
-    <loc>http://localhost:7000/products/oracle-service-cloud-dod</loc>
-    <lastmod>2016-06-14</lastmod>
+    <loc>http://localhost:4000/products/oracle-service-cloud-dod</loc>
+    <lastmod>2016-08-02</lastmod>
   </url>
   <url>
-    <loc>http://localhost:7000/products/oracle-service-cloud</loc>
-    <lastmod>2016-06-14</lastmod>
+    <loc>http://localhost:4000/products/oracle-service-cloud</loc>
+    <lastmod>2016-08-02</lastmod>
   </url>
   <url>
-    <loc>http://localhost:7000/products/piktochart</loc>
-    <lastmod>2016-06-14</lastmod>
+    <loc>http://localhost:4000/products/piktochart</loc>
+    <lastmod>2016-08-02</lastmod>
   </url>
   <url>
-    <loc>http://localhost:7000/products/plotly</loc>
-    <lastmod>2016-06-14</lastmod>
+    <loc>http://localhost:4000/products/plotly</loc>
+    <lastmod>2016-08-02</lastmod>
   </url>
   <url>
-    <loc>http://localhost:7000/products/popapp</loc>
-    <lastmod>2016-06-14</lastmod>
+    <loc>http://localhost:4000/products/popapp</loc>
+    <lastmod>2016-08-02</lastmod>
   </url>
   <url>
-    <loc>http://localhost:7000/products/powertrain-inc</loc>
-    <lastmod>2016-06-14</lastmod>
+    <loc>http://localhost:4000/products/powertrain-inc</loc>
+    <lastmod>2016-08-02</lastmod>
   </url>
   <url>
-    <loc>http://localhost:7000/products/project-hosts</loc>
-    <lastmod>2016-06-14</lastmod>
+    <loc>http://localhost:4000/products/project-hosts</loc>
+    <lastmod>2016-08-02</lastmod>
   </url>
   <url>
-    <loc>http://localhost:7000/products/proofpoint</loc>
-    <lastmod>2016-06-14</lastmod>
+    <loc>http://localhost:4000/products/proofpoint</loc>
+    <lastmod>2016-08-02</lastmod>
   </url>
   <url>
-    <loc>http://localhost:7000/products/qualys</loc>
-    <lastmod>2016-06-14</lastmod>
+    <loc>http://localhost:4000/products/qualys</loc>
+    <lastmod>2016-08-02</lastmod>
   </url>
   <url>
-    <loc>http://localhost:7000/products/salesforce</loc>
-    <lastmod>2016-06-14</lastmod>
+    <loc>http://localhost:4000/products/salesforce</loc>
+    <lastmod>2016-08-02</lastmod>
   </url>
   <url>
-    <loc>http://localhost:7000/products/sap</loc>
-    <lastmod>2016-06-14</lastmod>
+    <loc>http://localhost:4000/products/sap</loc>
+    <lastmod>2016-08-02</lastmod>
   </url>
   <url>
-    <loc>http://localhost:7000/products/screendoor</loc>
-    <lastmod>2016-06-14</lastmod>
+    <loc>http://localhost:4000/products/screendoor</loc>
+    <lastmod>2016-08-02</lastmod>
   </url>
   <url>
-    <loc>http://localhost:7000/products/scribd</loc>
-    <lastmod>2016-06-14</lastmod>
+    <loc>http://localhost:4000/products/scribd</loc>
+    <lastmod>2016-08-02</lastmod>
   </url>
   <url>
-    <loc>http://localhost:7000/products/seamlessdocs</loc>
-    <lastmod>2016-06-14</lastmod>
+    <loc>http://localhost:4000/products/seamlessdocs</loc>
+    <lastmod>2016-08-02</lastmod>
   </url>
   <url>
-    <loc>http://localhost:7000/products/securekey-technologies</loc>
-    <lastmod>2016-06-14</lastmod>
+    <loc>http://localhost:4000/products/securekey-technologies</loc>
+    <lastmod>2016-08-02</lastmod>
   </url>
   <url>
-    <loc>http://localhost:7000/products/sendwordnow</loc>
-    <lastmod>2016-06-14</lastmod>
+    <loc>http://localhost:4000/products/sendwordnow</loc>
+    <lastmod>2016-08-02</lastmod>
   </url>
   <url>
-    <loc>http://localhost:7000/products/service-now-com</loc>
-    <lastmod>2016-06-14</lastmod>
+    <loc>http://localhost:4000/products/service-now-com</loc>
+    <lastmod>2016-08-02</lastmod>
   </url>
   <url>
-    <loc>http://localhost:7000/products/skillsoft</loc>
-    <lastmod>2016-06-14</lastmod>
+    <loc>http://localhost:4000/products/skillsoft</loc>
+    <lastmod>2016-08-02</lastmod>
   </url>
   <url>
-    <loc>http://localhost:7000/products/slack</loc>
-    <lastmod>2016-06-14</lastmod>
+    <loc>http://localhost:4000/products/slack</loc>
+    <lastmod>2016-08-02</lastmod>
   </url>
   <url>
-    <loc>http://localhost:7000/products/smartprocure</loc>
-    <lastmod>2016-06-14</lastmod>
+    <loc>http://localhost:4000/products/smartprocure</loc>
+    <lastmod>2016-08-02</lastmod>
   </url>
   <url>
-    <loc>http://localhost:7000/products/social-oomph</loc>
-    <lastmod>2016-06-14</lastmod>
+    <loc>http://localhost:4000/products/social-oomph</loc>
+    <lastmod>2016-08-02</lastmod>
   </url>
   <url>
-    <loc>http://localhost:7000/products/socialtwist</loc>
-    <lastmod>2016-06-14</lastmod>
+    <loc>http://localhost:4000/products/socialtwist</loc>
+    <lastmod>2016-08-02</lastmod>
   </url>
   <url>
-    <loc>http://localhost:7000/products/socrata</loc>
-    <lastmod>2016-06-14</lastmod>
+    <loc>http://localhost:4000/products/socrata</loc>
+    <lastmod>2016-08-02</lastmod>
   </url>
   <url>
-    <loc>http://localhost:7000/products/softlayer</loc>
-    <lastmod>2016-06-14</lastmod>
+    <loc>http://localhost:4000/products/softlayer</loc>
+    <lastmod>2016-08-02</lastmod>
   </url>
   <url>
-    <loc>http://localhost:7000/products/storify</loc>
-    <lastmod>2016-06-14</lastmod>
+    <loc>http://localhost:4000/products/storify</loc>
+    <lastmod>2016-08-02</lastmod>
   </url>
   <url>
-    <loc>http://localhost:7000/products/survey-analytics</loc>
-    <lastmod>2016-06-14</lastmod>
+    <loc>http://localhost:4000/products/survey-analytics</loc>
+    <lastmod>2016-08-02</lastmod>
   </url>
   <url>
-    <loc>http://localhost:7000/products/surveymonkey</loc>
-    <lastmod>2016-06-14</lastmod>
+    <loc>http://localhost:4000/products/surveymonkey</loc>
+    <lastmod>2016-08-02</lastmod>
   </url>
   <url>
-    <loc>http://localhost:7000/products/thousandeyes</loc>
-    <lastmod>2016-06-14</lastmod>
+    <loc>http://localhost:4000/products/thousandeyes</loc>
+    <lastmod>2016-08-02</lastmod>
   </url>
   <url>
-    <loc>http://localhost:7000/products/thunderclap</loc>
-    <lastmod>2016-06-14</lastmod>
+    <loc>http://localhost:4000/products/thunderclap</loc>
+    <lastmod>2016-08-02</lastmod>
   </url>
   <url>
-    <loc>http://localhost:7000/products/tibco-software-inc</loc>
-    <lastmod>2016-06-14</lastmod>
+    <loc>http://localhost:4000/products/tibco-software-inc</loc>
+    <lastmod>2016-08-02</lastmod>
   </url>
   <url>
-    <loc>http://localhost:7000/products/tint</loc>
-    <lastmod>2016-06-14</lastmod>
+    <loc>http://localhost:4000/products/tint</loc>
+    <lastmod>2016-08-02</lastmod>
   </url>
   <url>
-    <loc>http://localhost:7000/products/trapwire</loc>
-    <lastmod>2016-06-14</lastmod>
+    <loc>http://localhost:4000/products/trapwire</loc>
+    <lastmod>2016-08-02</lastmod>
   </url>
   <url>
-    <loc>http://localhost:7000/products/trello</loc>
-    <lastmod>2016-06-14</lastmod>
+    <loc>http://localhost:4000/products/trello</loc>
+    <lastmod>2016-08-02</lastmod>
   </url>
   <url>
-    <loc>http://localhost:7000/products/tubemogul</loc>
-    <lastmod>2016-06-14</lastmod>
+    <loc>http://localhost:4000/products/tubemogul</loc>
+    <lastmod>2016-08-02</lastmod>
   </url>
   <url>
-    <loc>http://localhost:7000/products/unisys-edge</loc>
-    <lastmod>2016-06-14</lastmod>
+    <loc>http://localhost:4000/products/unisys-edge</loc>
+    <lastmod>2016-08-02</lastmod>
   </url>
   <url>
-    <loc>http://localhost:7000/products/unisys-spcg</loc>
-    <lastmod>2016-06-14</lastmod>
+    <loc>http://localhost:4000/products/unisys-spcg</loc>
+    <lastmod>2016-08-02</lastmod>
   </url>
   <url>
-    <loc>http://localhost:7000/products/usda-finance</loc>
-    <lastmod>2016-06-14</lastmod>
+    <loc>http://localhost:4000/products/usda-finance</loc>
+    <lastmod>2016-08-02</lastmod>
   </url>
   <url>
-    <loc>http://localhost:7000/products/usda-it-center</loc>
-    <lastmod>2016-06-14</lastmod>
+    <loc>http://localhost:4000/products/usda-it-center</loc>
+    <lastmod>2016-08-02</lastmod>
   </url>
   <url>
-    <loc>http://localhost:7000/products/uservoice</loc>
-    <lastmod>2016-06-14</lastmod>
+    <loc>http://localhost:4000/products/uservoice</loc>
+    <lastmod>2016-08-02</lastmod>
   </url>
   <url>
-    <loc>http://localhost:7000/products/vazata</loc>
-    <lastmod>2016-06-14</lastmod>
+    <loc>http://localhost:4000/products/vazata</loc>
+    <lastmod>2016-08-02</lastmod>
   </url>
   <url>
-    <loc>http://localhost:7000/products/veracode</loc>
-    <lastmod>2016-06-14</lastmod>
+    <loc>http://localhost:4000/products/veracode</loc>
+    <lastmod>2016-08-02</lastmod>
   </url>
   <url>
-    <loc>http://localhost:7000/products/virtustream</loc>
-    <lastmod>2016-06-14</lastmod>
+    <loc>http://localhost:4000/products/virtustream</loc>
+    <lastmod>2016-08-02</lastmod>
   </url>
   <url>
-    <loc>http://localhost:7000/products/vmware</loc>
-    <lastmod>2016-06-14</lastmod>
+    <loc>http://localhost:4000/products/vmware</loc>
+    <lastmod>2016-08-02</lastmod>
   </url>
   <url>
-    <loc>http://localhost:7000/products/wikispaces</loc>
-    <lastmod>2016-06-14</lastmod>
+    <loc>http://localhost:4000/products/wikispaces</loc>
+    <lastmod>2016-08-02</lastmod>
   </url>
   <url>
-    <loc>http://localhost:7000/products/yammer</loc>
-    <lastmod>2016-06-14</lastmod>
+    <loc>http://localhost:4000/products/yammer</loc>
+    <lastmod>2016-08-02</lastmod>
   </url>
   <url>
-    <loc>http://localhost:7000/products/zeemaps</loc>
-    <lastmod>2016-06-14</lastmod>
+    <loc>http://localhost:4000/products/zeemaps</loc>
+    <lastmod>2016-08-02</lastmod>
   </url>
 </urlset>

--- a/spec/factories/ato_status.rb
+++ b/spec/factories/ato_status.rb
@@ -1,0 +1,9 @@
+FactoryGirl.define do
+  factory :ato_status do
+    pending false
+    url "https://google.com"
+
+    ato_type
+    product
+  end
+end

--- a/spec/factories/product.rb
+++ b/spec/factories/product.rb
@@ -47,5 +47,12 @@ FactoryGirl.define do
         create(:product_request, product: product)
       end
     end
+
+    trait :with_ato_type do
+      after(:create) do |product|
+        ato_type = create(:ato_type)
+        create(:ato_status, ato_type: ato_type, product: product)
+      end
+    end
   end
 end

--- a/spec/features/guests/guest_visits_product_page_spec.rb
+++ b/spec/features/guests/guest_visits_product_page_spec.rb
@@ -1,0 +1,13 @@
+require "rails_helper"
+
+feature "Guest visits Product page" do
+  scenario "and sees a Product’s ATO Statuses" do
+    visit product_path(product)
+
+    expect(page).to have_css(".checked", text: product.ato_types.first.name)
+  end
+
+  def product
+    @product ||= create(:product, :with_ato_type)
+  end
+end


### PR DESCRIPTION
Displays the ATO Types a Product has along with ATO Types the Product does not have. Also ignores the sitemap file to force the generation of a sitemap for each environment.

* Display ATO Types in Product Page
* Ignore sitemap file to force the generation of a sitemap in each environment