### PR TITLE
List Product Contracts on Product Page

### DIFF
--- a/app/assets/stylesheets/products/_show.scss
+++ b/app/assets/stylesheets/products/_show.scss
@@ -57,6 +57,7 @@
   }
 
   .column-container {
+    @include clearfix;
     margin-top: 1em;
   }
 
@@ -72,6 +73,12 @@
   .product-content {
     @include span-columns(9);
     @include omega;
+    margin-bottom: 6em;
+
+    h2 {
+      font-size: 1.5em;
+      margin-bottom: 0.5em;
+    }
 
     p {
       margin-top: 0;

--- a/app/presenters/product_presenter.rb
+++ b/app/presenters/product_presenter.rb
@@ -19,7 +19,15 @@ class ProductPresenter
     @product_ato_statuses ||= product.ato_statuses
   end
 
+  def product_contracts
+    @product_contracts ||= product.contracts
+  end
+
   def remaining_ato_types
     AtoType.where.not(id: product_ato_types.select(:id))
+  end
+
+  def remaining_contracts
+    Contract.where.not(id: product_contracts.select(:id))
   end
 end

--- a/app/views/products/_contract.html.haml
+++ b/app/views/products/_contract.html.haml
@@ -1,0 +1,10 @@
+= content_tag_for :li, contract do
+  %button.usa-button-unstyled{ "aria-controls" => "contract-#{contract_counter}", "aria-expanded" => "false" }
+    = contract.name
+  .usa-accordion-content{ id: "contract-#{contract_counter}", "aria-hidden" => "true" }
+    %p
+      = contract.contact_email
+    %p
+      = contract.description
+    %ul
+      = contract.steps

--- a/app/views/products/_contracts.html.haml
+++ b/app/views/products/_contracts.html.haml
@@ -1,0 +1,6 @@
+%h2
+  = t(".heading")
+.usa-accordion
+  %ul.usa-unstyled-list
+    = render partial: "contract",
+      collection: product_presenter.product_contracts

--- a/app/views/products/_product_content.html.haml
+++ b/app/views/products/_product_content.html.haml
@@ -22,3 +22,5 @@
 .column-container
   .product-ato-types
     = render "ato_types", product_presenter: product_presenter
+.product-contracts
+  = render "contracts", product_presenter: product_presenter

--- a/app/views/products/show.html.haml
+++ b/app/views/products/show.html.haml
@@ -12,7 +12,6 @@
     = render "product_content",
       product_presenter: @product_presenter
 
-
 - unless signed_in?
   = render "modules/product_owner_modal"
 

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -187,6 +187,8 @@ en:
   products:
     ato_types:
       heading: Authority to Operate (ATO)
+    contracts:
+      heading: Procurement Options
     index:
       categories: Categories
       header: Discover Your Team’s Next Favorite App

--- a/spec/factories/contract.rb
+++ b/spec/factories/contract.rb
@@ -1,0 +1,7 @@
+FactoryGirl.define do
+  factory :contract do
+    description "Cool contract brochacho."
+    sequence(:name) { |n| "Contract-#{n}" }
+    sequence(:slug) { |n| "contract-#{n}" }
+  end
+end

--- a/spec/factories/product.rb
+++ b/spec/factories/product.rb
@@ -12,10 +12,24 @@ FactoryGirl.define do
       end
     end
 
+    trait :with_ato_type do
+      after(:create) do |product|
+        ato_type = create(:ato_type)
+        create(:ato_status, ato_type: ato_type, product: product)
+      end
+    end
+
     trait :with_category do
       after(:create) do |product|
         category = create(:category)
         create(:product_category, category: category, product: product)
+      end
+    end
+
+    trait :with_contract do
+      after(:create) do |product|
+        contract = create(:contract)
+        create(:product_contract, contract: contract, product: product)
       end
     end
 
@@ -45,13 +59,6 @@ FactoryGirl.define do
     trait :with_product_request do
       after(:create) do |product|
         create(:product_request, product: product)
-      end
-    end
-
-    trait :with_ato_type do
-      after(:create) do |product|
-        ato_type = create(:ato_type)
-        create(:ato_status, ato_type: ato_type, product: product)
       end
     end
   end

--- a/spec/factories/product_contract.rb
+++ b/spec/factories/product_contract.rb
@@ -1,0 +1,6 @@
+FactoryGirl.define do
+  factory :product_contract do
+    contract
+    product
+  end
+end

--- a/spec/features/guests/guest_visits_product_page_spec.rb
+++ b/spec/features/guests/guest_visits_product_page_spec.rb
@@ -1,13 +1,18 @@
 require "rails_helper"
 
 feature "Guest visits Product page" do
-  scenario "and sees a Product’s ATO Statuses" do
-    visit product_path(product)
+  before { visit product_path(product) }
 
+  scenario "and sees a Product’s ATO Statuses" do
     expect(page).to have_css(".checked", text: product.ato_types.first.name)
   end
 
+  scenario "and sees a Product’s Procurement Options" do
+    expect(page).
+      to have_css(".product-contracts", text: product.contracts.first.name)
+  end
+
   def product
-    @product ||= create(:product, :with_ato_type)
+    @product ||= create(:product, :with_ato_type, :with_contract)
   end
 end


### PR DESCRIPTION
Adds a Procurement Options section to the Product show page that adds accordions for each Contract associated with a Product.

* Add Procurement Options section to the Product show page
* Display accordion-style list for each Product Contract