### PR TITLE
Add Contract Officer and Authorizing Official Contact Fields to Product Request

### DIFF
--- a/app/assets/javascripts/product-show.js
+++ b/app/assets/javascripts/product-show.js
@@ -33,17 +33,15 @@ appsGov.productShow = {
   },
 
   insertSuccessMessage: function() {
-    var form = $(".new-product-form").html();
+    var form = $(".gov-user-sign-up .new_product_request").html();
     $("#government-user-signup .success-message").append(
       "<div class='slide-2'>" +
         "<h1>You’re all set!</h1>" +
         "<p>" +
-          "Lorem ipsum Culpa aute ex enim in dolor ut ex exercitation quis" +
-          "incididunt sint eu." +
+          "Finish your Product Request by adding your Authorizing Official" +
+          " and Contract Officer contact information." +
         "</p>" +
-        "<div class='modal-actions'>"+
-          form +
-        "</div>" +
+        form +
       "</div>"
     );
     $(".modal-actions .modal-trigger").unbind().removeClass("modal-trigger");

--- a/app/controllers/government_users/product_requests_controller.rb
+++ b/app/controllers/government_users/product_requests_controller.rb
@@ -1,0 +1,35 @@
+module GovernmentUsers
+  class ProductRequestsController < GovernmentUsersController
+    def new
+      @product = product
+    end
+
+    def create
+      @product_request = ProductRequest.new(product_request_params)
+
+      if @product_request.draft_creation
+        flash[:success] =
+          I18n.t("government_users.product_requests.create.success")
+      else
+        flash[:error] =
+          I18n.t("government_users.product_requests.create.failure")
+      end
+      redirect_to product_path(product)
+    end
+
+    private
+
+    def product
+      Product.find(params[:product_id])
+    end
+
+    def product_request_params
+      params.
+        require(:product_request).
+        permit(
+          :authorizing_official_email,
+          :contract_officer_email
+        ).merge(product: product, user: signed_in_user)
+    end
+  end
+end

--- a/app/controllers/government_users_controller.rb
+++ b/app/controllers/government_users_controller.rb
@@ -1,0 +1,6 @@
+class GovernmentUsersController < ApplicationController
+  load_and_authorize_resource
+  rescue_from CanCan::AccessDenied do
+    redirect_to new_government_user_registration_path
+  end
+end

--- a/app/controllers/product_requests_controller.rb
+++ b/app/controllers/product_requests_controller.rb
@@ -1,8 +1,5 @@
 class ProductRequestsController < ApplicationController
   load_and_authorize_resource
-  rescue_from CanCan::AccessDenied do
-    redirect_to new_product_owner_registration_path
-  end
 
   def create
     @product_request = ProductRequest.new(product_request_params)

--- a/app/models/product_request.rb
+++ b/app/models/product_request.rb
@@ -5,6 +5,7 @@ class ProductRequest < ActiveRecord::Base
   has_drafts
 
   validates :product, :user, presence: true
+
   validates_uniqueness_of :user_id, scope: :product_id
 
   def name

--- a/app/views/government_users/product_requests/_form.html.haml
+++ b/app/views/government_users/product_requests/_form.html.haml
@@ -1,0 +1,5 @@
+= simple_form_for [:government_users, product, product_request] do |f|
+  = f.input :authorizing_official_email, required: true
+  = f.input :contract_officer_email, required: true
+  .form-actions
+    = f.submit

--- a/app/views/government_users/product_requests/new.html.haml
+++ b/app/views/government_users/product_requests/new.html.haml
@@ -1,0 +1,7 @@
+.usa-grid
+  %h1
+    = t(".heading")
+
+  = render "form",
+    product: @product,
+    product_request: @product.product_requests.new

--- a/app/views/products/_gov_product_request_modal.html.haml
+++ b/app/views/products/_gov_product_request_modal.html.haml
@@ -1,0 +1,10 @@
+.modal.gov-user-sign-up#gov-product-request
+  .heading
+    %h1
+      = t(".heading")
+  = render "government_users/product_requests/form",
+    product: product,
+    product_request: product_request
+  .close.modal-close
+  .loading
+    = image_tag("loading-ring.svg")

--- a/app/views/products/_product_sidebar.html.haml
+++ b/app/views/products/_product_sidebar.html.haml
@@ -3,11 +3,14 @@
 
 - if no_users_signed_in? || government_user_signed_in?
   .new-product-form
-    = simple_form_for [product, product_request] do |f|
-      = f.input :product_id, value: product.id, as: :hidden
-      - if no_users_signed_in?
-        = f.submit t(".get_product"),
-          class: "usa-button modal-trigger",
-          data: {modal_id: "government-user-signup"}
-      - else
-        = f.submit t(".get_product"), class: "usa-button"
+    - if no_users_signed_in?
+      = link_to t(".get_product"),
+        new_government_users_product_product_request_path(product),
+        class: "usa-button modal-trigger",
+        data: {modal_id: "government-user-signup"}
+    - else
+      = link_to t(".get_product"),
+        new_government_users_product_product_request_path(product),
+        class: "usa-button modal-trigger",
+        data: {modal_id: "gov-product-request"}
+

--- a/app/views/products/show.html.haml
+++ b/app/views/products/show.html.haml
@@ -14,4 +14,8 @@
 
 - unless signed_in?
   = render "modules/product_owner_modal"
+- unless product_owner_signed_in?
+  = render "gov_product_request_modal",
+  product: @product_presenter.product,
+    product_request: @product_presenter.new_product_request
 

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -89,6 +89,12 @@ en:
   government_users:
     failures:
       no_gov_email: You must have a .gov or .mil email address to sign up.
+    product_requests:
+      create:
+        failure: An error occured. Please try again.
+        success: Product Requested!
+      new:
+        heading: Request Product
     registrations:
       form:
         organization_name: Team/Organization Name
@@ -191,6 +197,8 @@ en:
       heading: Authority to Operate (ATO)
     contracts:
       heading: Procurement Options
+    gov_product_request_modal:
+      heading: New Product Request
     index:
       categories: Categories
       header: Discover Your Team’s Next Favorite App

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -20,6 +20,12 @@ Rails.application.routes.draw do
     end
   end
 
+  namespace :government_users do
+    resources :products, shallow: true do
+      resources :product_requests, only: [:create, :new]
+    end
+  end
+
   namespace :product_owners do
     resources :product_requests, only: [:new, :create, :destroy]
     resources :products, only: [:edit, :update]
@@ -38,10 +44,7 @@ Rails.application.routes.draw do
   get "/products/search", to: "products#search", as: :products_search
 
   resources :categories, only: [:show]
-
-  resources :products, only: [:index, :show] do
-    resources :product_requests, only: [:create]
-  end
+  resources :products, only: [:index, :show]
 
   root to: "products#index"
 end

--- a/db/migrate/20160810133015_add_officers_to_product_requests.rb
+++ b/db/migrate/20160810133015_add_officers_to_product_requests.rb
@@ -1,0 +1,6 @@
+class AddOfficersToProductRequests < ActiveRecord::Migration
+  def change
+    add_column :product_requests, :contract_officer_email, :string
+    add_column :product_requests, :authorizing_official_email, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20160808195601) do
+ActiveRecord::Schema.define(version: 20160810133015) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -129,11 +129,13 @@ ActiveRecord::Schema.define(version: 20160808195601) do
   end
 
   create_table "product_requests", force: :cascade do |t|
-    t.integer  "product_id",   null: false
-    t.integer  "user_id",      null: false
+    t.integer  "product_id",                 null: false
+    t.integer  "user_id",                    null: false
     t.integer  "draft_id"
     t.datetime "published_at"
     t.datetime "trashed_at"
+    t.string   "contract_officer_email"
+    t.string   "authorizing_official_email"
   end
 
   add_index "product_requests", ["product_id"], name: "index_product_requests_on_product_id", using: :btree

--- a/spec/features/government_users/government_user_creates_product_request_spec.rb
+++ b/spec/features/government_users/government_user_creates_product_request_spec.rb
@@ -7,7 +7,11 @@ feature "A Government User creates a Product Request" do
     scenario "and successfully creates the request" do
       visit product_path(product)
 
-      click_button t("products.product_sidebar.get_product")
+      click_on t("products.product_sidebar.get_product")
+
+      fill_in "Authorizing official email", with: "email@email.com"
+      fill_in "Contract officer email", with: "email@email.com"
+      click_on "Create Product request"
 
       expect(page).to have_text t("product_requests.create.success")
     end
@@ -18,7 +22,11 @@ feature "A Government User creates a Product Request" do
       create(:product_request, product: product, user: user)
       visit product_path(product)
 
-      click_button t("products.product_sidebar.get_product")
+      click_on t("products.product_sidebar.get_product")
+
+      fill_in "Authorizing official email", with: "email@email.com"
+      fill_in "Contract officer email", with: "email@email.com"
+      click_on "Create Product request"
 
       expect(page).to have_text t("product_requests.create.failure")
     end


### PR DESCRIPTION
Adds an extra step to the creation of a Product Request for Government Users.

* Add Contract Officer and Authorizing Official Email fields to Product Request
* Convert submission button for modal form trigger to force gov users to fill in new fields before submitting a Product Request
* Create ProductRequest fallback view for non-js Users