### PR TITLE
Add Product Keywords to Algolia Index

### DIFF
--- a/app/models/product.rb
+++ b/app/models/product.rb
@@ -43,6 +43,14 @@ class Product < ActiveRecord::Base
 
   algoliasearch enqueue: :trigger_delayed_job, sanitize: true do
     attribute :name, :logo_url, :short_description, :slug
+
+    add_attribute :algolia_keywords
+  end
+
+  def algolia_keywords
+    product_keywords.select { |pk| pk.valid? }.map do |pk|
+      { name: pk.keyword.name }
+    end
   end
 
   def self.most_popular


### PR DESCRIPTION
Adds Product Keywords to Product Index in Algolia to improve search experience.

* Index Product Keywords in Product Index for Algolia