### PR TITLE
BUGFIX: Listing Page Broken. Add Listing Link to Nav

### DIFF
--- a/app/assets/stylesheets/modules/_navigation.scss
+++ b/app/assets/stylesheets/modules/_navigation.scss
@@ -28,11 +28,6 @@
     }
   }
 
-  ul {
-    float: right;
-    margin: 0;
-  }
-
   .dropdown-parent {
     position: relative;
   }
@@ -70,6 +65,8 @@
 }
 
 .app-auth-links {
+  float: right;
+  margin: 0;
 
   a {
     @include outline-button(darken($light-gray,5));
@@ -101,6 +98,25 @@
       &:hover {
         background-color: darken($color-primary, 7);
       }
+    }
+  }
+}
+
+.app-page-links {
+  float: left;
+  margin: 0 0 0 1.5em;
+
+  a {
+    color: darken($medium-gray, 30);
+    font-size: 0.9em;
+    font-weight: bold;
+  }
+
+  li {
+    margin: 0.5em 0 0 1em;
+
+    &:first-child {
+      margin-left: 0;
     }
   }
 }

--- a/app/views/modules/_navigation.html.haml
+++ b/app/views/modules/_navigation.html.haml
@@ -4,6 +4,10 @@
     .usa-grid
       %h1.app-logo
         = link_to t("titles.application"), root_path
+      - if !signed_in? || product_owner_signed_in?
+        %ul.app-page-links
+          %li
+            = link_to t(".list_product"), page_path("listing")
       %ul.app-auth-links
         - if signed_in?
           - if product_owner_signed_in? || user_signed_in?

--- a/app/views/modules/_product_owner_modal.html.haml
+++ b/app/views/modules/_product_owner_modal.html.haml
@@ -4,6 +4,8 @@
       = t(".heading")
     %p
       = t(".subheading")
-  = render "modules/product_owner_signup_form",
-    product_id: @product_presenter.product.id || nil
+  - if defined? product_id
+    = render "modules/product_owner_signup_form", product_id: product_id
+  - else
+    = render "modules/product_owner_signup_form"
   .close.modal-close

--- a/app/views/modules/_product_owner_signup_form.html.haml
+++ b/app/views/modules/_product_owner_signup_form.html.haml
@@ -8,6 +8,7 @@
     = f.input :password,
       required: true,
       hint: ("#{@minimum_password_length} characters minimum" if @minimum_password_length)
-    = f.hidden_field :product_id, value: product_id
+    - if defined? product_id
+      = f.hidden_field :product_id, value: product_id
   .form-actions
     = f.button :submit, "Sign up"

--- a/app/views/products/show.html.haml
+++ b/app/views/products/show.html.haml
@@ -13,7 +13,8 @@
       product_presenter: @product_presenter
 
 - unless signed_in?
-  = render "modules/product_owner_modal"
+  = render "modules/product_owner_modal",
+    product_id: @product_presenter.product.id
 - unless product_owner_signed_in?
   = render "gov_product_request_modal",
   product: @product_presenter.product,

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -143,6 +143,7 @@ en:
     navigation:
       dashboard: Dashboard
       edit_account: Edit Account
+      list_product: List Your Product
       sign_in: Sign in
       sign_out: Sign Out
       sign_up: Sign Up


### PR DESCRIPTION
Fixes issues with the product modal view expecting @product_presenter to be defined to render the product_owner signup form. Also adds a link to the listing page if no one is signed in or a Product Owner is signed in.

* Add conditional for product_id definition in product_owner sign up form
* Pass product_id to product_owner_modal
* Add listing page link to App nav