### PR TITLE
Create Subcategories and Reorganize Categories

### DIFF
--- a/app/models/category.rb
+++ b/app/models/category.rb
@@ -1,11 +1,20 @@
 class Category < ActiveRecord::Base
   extend FriendlyId
 
-  has_many :products, through: :product_categories
-  has_many :product_categories
+  has_many :subcategories
 
   friendly_id :name, use: [:slugged, :finders]
 
   validates :name, presence: true
   validates :slug, presence: true, uniqueness: true
+
+  def products
+    Product.joins(:product_subcategories).merge(product_subcategories).uniq
+  end
+
+  private
+
+  def product_subcategories
+    ProductSubcategory.where(subcategory: subcategories)
+  end
 end

--- a/app/models/product.rb
+++ b/app/models/product.rb
@@ -8,8 +8,8 @@ class Product < ActiveRecord::Base
   has_many :ato_types, through: :ato_statuses
   has_many :ato_statuses
 
-  has_many :categories, through: :product_categories
-  has_many :product_categories
+  has_many :subcategories, through: :product_subcategories
+  has_many :product_subcategories
 
   has_many :contracts, through: :product_contracts
   has_many :product_contracts

--- a/app/models/product_category.rb
+++ b/app/models/product_category.rb
@@ -1,6 +1,0 @@
-class ProductCategory < ActiveRecord::Base
-  belongs_to :category
-  belongs_to :product
-
-  validates :category, :product, presence: true
-end

--- a/app/models/product_subcategory.rb
+++ b/app/models/product_subcategory.rb
@@ -1,0 +1,6 @@
+class ProductSubcategory < ActiveRecord::Base
+  belongs_to :subcategory
+  belongs_to :product
+
+  validates :subcategory, :product, presence: true
+end

--- a/app/models/subcategory.rb
+++ b/app/models/subcategory.rb
@@ -1,0 +1,12 @@
+class Subcategory < ActiveRecord::Base
+  extend FriendlyId
+
+  belongs_to :category
+  has_many :products, through: :product_subcategories
+  has_many :product_subcategories
+
+  friendly_id :name, use: [:slugged, :finders]
+
+  validates :name, presence: true
+  validates :slug, presence: true, uniqueness: true
+end

--- a/db/migrate/20160816140005_create_subcategories.rb
+++ b/db/migrate/20160816140005_create_subcategories.rb
@@ -1,0 +1,9 @@
+class CreateSubcategories < ActiveRecord::Migration
+  def change
+    create_table :subcategories do |t|
+      t.string :name, null: false
+      t.string :slug, null: false
+      t.references :category, null: false
+    end
+  end
+end

--- a/db/migrate/20160816140100_rename_product_categories_to_product_subcategories.rb
+++ b/db/migrate/20160816140100_rename_product_categories_to_product_subcategories.rb
@@ -1,0 +1,13 @@
+class RenameProductCategoriesToProductSubcategories < ActiveRecord::Migration
+  def self.up
+    remove_reference :product_categories, :category
+    rename_table :product_categories, :product_subcategories
+    add_reference :product_subcategories, :subcategory, index: true
+  end
+
+  def self.down
+    remove_reference :product_subcategories, :subcategory
+    rename_table :product_subcategories, :product_categories
+    add_reference :product_categories, :category, index: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20160810133015) do
+ActiveRecord::Schema.define(version: 20160816140100) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -107,14 +107,6 @@ ActiveRecord::Schema.define(version: 20160810133015) do
     t.text    "content",   null: false
   end
 
-  create_table "product_categories", force: :cascade do |t|
-    t.integer "category_id", null: false
-    t.integer "product_id",  null: false
-  end
-
-  add_index "product_categories", ["category_id"], name: "index_product_categories_on_category_id", using: :btree
-  add_index "product_categories", ["product_id"], name: "index_product_categories_on_product_id", using: :btree
-
   create_table "product_contracts", force: :cascade do |t|
     t.integer "contract_id", null: false
     t.integer "product_id",  null: false
@@ -147,6 +139,14 @@ ActiveRecord::Schema.define(version: 20160810133015) do
     t.string  "url"
   end
 
+  create_table "product_subcategories", force: :cascade do |t|
+    t.integer "product_id",     null: false
+    t.integer "subcategory_id"
+  end
+
+  add_index "product_subcategories", ["product_id"], name: "index_product_subcategories_on_product_id", using: :btree
+  add_index "product_subcategories", ["subcategory_id"], name: "index_product_subcategories_on_subcategory_id", using: :btree
+
   create_table "products", force: :cascade do |t|
     t.text     "long_description",                     null: false
     t.string   "fedramp_inprocess_agency"
@@ -177,6 +177,12 @@ ActiveRecord::Schema.define(version: 20160810133015) do
     t.text   "description", null: false
     t.string "name",        null: false
     t.string "slug",        null: false
+  end
+
+  create_table "subcategories", force: :cascade do |t|
+    t.string  "name",        null: false
+    t.string  "slug",        null: false
+    t.integer "category_id", null: false
   end
 
   create_table "users", force: :cascade do |t|

--- a/spec/factories/product.rb
+++ b/spec/factories/product.rb
@@ -19,10 +19,10 @@ FactoryGirl.define do
       end
     end
 
-    trait :with_category do
+    trait :with_subcategory do
       after(:create) do |product|
-        category = create(:category)
-        create(:product_category, category: category, product: product)
+        subcategory = create(:subcategory)
+        create(:product_subcategory, subcategory: subcategory, product: product)
       end
     end
 

--- a/spec/factories/product_category.rb
+++ b/spec/factories/product_category.rb
@@ -1,6 +1,0 @@
-FactoryGirl.define do
-  factory :product_category do
-    category
-    product
-  end
-end

--- a/spec/factories/product_subcategory.rb
+++ b/spec/factories/product_subcategory.rb
@@ -1,0 +1,6 @@
+FactoryGirl.define do
+  factory :product_subcategory do
+    subcategory
+    product
+  end
+end

--- a/spec/factories/subcategory.rb
+++ b/spec/factories/subcategory.rb
@@ -1,11 +1,11 @@
 FactoryGirl.define do
-  factory :category do
+  factory :subcategory do
     sequence(:name) { |n| "Subcategory-#{n}" }
+    category
 
     trait :with_products do
-      after(:create) do |category|
+      after(:create) do |subcategory|
         products = create_list(:product, 3)
-        subcategory = create(:subcategory, category: category)
         products.each do |product|
           create(
             :product_subcategory,

--- a/spec/models/category_spec.rb
+++ b/spec/models/category_spec.rb
@@ -1,8 +1,7 @@
 require "rails_helper"
 
 describe Category do
-  it { should have_many :product_categories }
-  it { should have_many(:products).through(:product_categories) }
+  it { should have_many :subcategories }
   it { should validate_presence_of :name }
 
   context "uniqueness" do

--- a/spec/models/product_category_spec.rb
+++ b/spec/models/product_category_spec.rb
@@ -1,8 +1,0 @@
-require "rails_helper"
-
-describe ProductCategory do
-  it { should belong_to :category }
-  it { should belong_to :product }
-  it { should validate_presence_of :category }
-  it { should validate_presence_of :product }
-end

--- a/spec/models/product_spec.rb
+++ b/spec/models/product_spec.rb
@@ -5,11 +5,12 @@ describe Product do
     it { should have_many(:agencies).through(:customers) }
     it { should have_many :ato_statuses }
     it { should have_many(:ato_types).through(:ato_statuses) }
-    it { should have_many(:categories).through(:product_categories) }
     it { should have_many(:contracts).through(:product_contracts) }
     it { should have_many :product_requests }
     it { should have_many :product_reviews }
+    it { should have_many(:product_subcategories) }
     it { should have_many(:reviews).through(:product_reviews) }
+    it { should have_many(:subcategories).through(:product_subcategories) }
     it { should have_many(:users).through(:product_requests) }
   end
 

--- a/spec/models/product_subcategory_spec.rb
+++ b/spec/models/product_subcategory_spec.rb
@@ -1,0 +1,8 @@
+require "rails_helper"
+
+describe ProductSubcategory do
+  it { should belong_to :product }
+  it { should belong_to :subcategory }
+  it { should validate_presence_of :product }
+  it { should validate_presence_of :subcategory }
+end

--- a/spec/models/subcategory_spec.rb
+++ b/spec/models/subcategory_spec.rb
@@ -1,0 +1,12 @@
+require "rails_helper"
+
+describe Subcategory do
+  it { should have_many :product_subcategories }
+  it { should have_many(:products).through(:product_subcategories) }
+  it { should validate_presence_of :name }
+
+  context "uniqueness" do
+    subject { create(:subcategory) }
+    it { should validate_uniqueness_of :slug }
+  end
+end


### PR DESCRIPTION
Creates Subcategories for handling the categorization of Products. Subcategories belong to Categories and enables more specific categorization of Products.

* Create Subcategory
* Change ProductCategory to ProductSubcategory and update relationships and references
* Category is now the parent of Subcategory
* Update Category model to enable retrieval of Products (per Stroup's suggestion)