### PR TITLE
Force HTTPS for use of cookie_store

### DIFF
--- a/config/initializers/session_store.rb
+++ b/config/initializers/session_store.rb
@@ -1,3 +1,6 @@
 # Be sure to restart your server when you modify this file.
 
-Rails.application.config.session_store :cookie_store, key: '_apps-gov-v2_session'
+Rails.application.config.session_store \
+  :cookie_store,
+  key: "_apps-gov-v2_session",
+  secure: Rails.env.production?


### PR DESCRIPTION
Force HTTPS for use of cookie_store in production.

* Set secure option to true for cookie_store when in Production