### PR TITLE
Add Dependent Deletion To Models

### DIFF
--- a/app/models/ato_type.rb
+++ b/app/models/ato_type.rb
@@ -7,5 +7,5 @@ class AtoType < ActiveRecord::Base
   validates :slug, presence: true, uniqueness: true
 
   has_many :products, through: :ato_statuses
-  has_many :ato_statuses
+  has_many :ato_statuses, dependent: :destroy
 end

--- a/app/models/category.rb
+++ b/app/models/category.rb
@@ -1,7 +1,7 @@
 class Category < ActiveRecord::Base
   extend FriendlyId
 
-  has_many :subcategories
+  has_many :subcategories, dependent: :destroy
 
   friendly_id :name, use: [:slugged, :finders]
 

--- a/app/models/product.rb
+++ b/app/models/product.rb
@@ -6,22 +6,22 @@ class Product < ActiveRecord::Base
   has_many :customers
 
   has_many :ato_types, through: :ato_statuses
-  has_many :ato_statuses
+  has_many :ato_statuses, dependent: :destroy
 
   has_many :subcategories, through: :product_subcategories
-  has_many :product_subcategories
+  has_many :product_subcategories, dependent: :destroy
 
   has_many :contracts, through: :product_contracts
-  has_many :product_contracts
+  has_many :product_contracts, dependent: :destroy
 
   has_many :keywords, through: :product_keywords
-  has_many :product_keywords
+  has_many :product_keywords, dependent: :destroy
 
-  has_many :product_reviews
+  has_many :product_reviews, dependent: :destroy
   has_many :reviews, through: :product_reviews
 
   has_many :users, through: :product_requests
-  has_many :product_requests
+  has_many :product_requests, dependent: :destroy
 
   has_drafts
 

--- a/config/newrelic.yml
+++ b/config/newrelic.yml
@@ -1,34 +1,16 @@
 common: &default_settings
   app_name: "apps-gov-v2"
-  audit_log:
-    enabled: false
-  browser_monitoring:
-    auto_instrument: true
-  capture_params: false
-  developer_mode: false
-  error_collector:
-    capture_source: true
-    enabled: true
-    ignore_errors: "ActionController::RoutingError,Sinatra::NotFound"
   license_key: "<%= ENV["NEW_RELIC_LICENSE_KEY"] %>"
   log_level: info
-  monitor_mode: true
-  transaction_tracer:
-    enabled: true
-    record_sql: obfuscated
-    stack_trace_threshold: 0.500
-    transaction_threshold: apdex_f
 development:
+  app_name: apps-gov-v2 (Development)
   <<: *default_settings
-  monitor_mode: false
   developer_mode: true
 test:
   <<: *default_settings
   monitor_mode: false
 production:
   <<: *default_settings
-  monitor_mode: true
 staging:
   <<: *default_settings
   app_name: "apps-gov-v2 (Staging)"
-  monitor_mode: true

--- a/db/seeds/ato_types.rb
+++ b/db/seeds/ato_types.rb
@@ -16,6 +16,6 @@ ato_types = [
 
 ActiveRecord::Base.transaction do
   ato_types.each do |ato_type|
-    AtoType.create!(ato_type)
+    AtoType.find_or_create_by!(ato_type)
   end
 end

--- a/spec/models/ato_type_spec.rb
+++ b/spec/models/ato_type_spec.rb
@@ -1,7 +1,7 @@
 require "rails_helper"
 
 describe AtoType do
-  it { should have_many :ato_statuses }
+  it { should have_many(:ato_statuses).dependent(:destroy) }
   it { should have_many(:products).through(:ato_statuses) }
   it { should validate_presence_of :name }
   it { should validate_presence_of :slug }

--- a/spec/models/category_spec.rb
+++ b/spec/models/category_spec.rb
@@ -1,7 +1,7 @@
 require "rails_helper"
 
 describe Category do
-  it { should have_many :subcategories }
+  it { should have_many(:subcategories).dependent(:destroy) }
   it { should validate_presence_of :name }
 
   context "uniqueness" do

--- a/spec/models/product_spec.rb
+++ b/spec/models/product_spec.rb
@@ -3,12 +3,12 @@ require "rails_helper"
 describe Product do
   context "associations" do
     it { should have_many(:agencies).through(:customers) }
-    it { should have_many :ato_statuses }
+    it { should have_many(:ato_statuses).dependent(:destroy) }
     it { should have_many(:ato_types).through(:ato_statuses) }
     it { should have_many(:contracts).through(:product_contracts) }
-    it { should have_many :product_requests }
-    it { should have_many :product_reviews }
-    it { should have_many(:product_subcategories) }
+    it { should have_many(:product_requests).dependent(:destroy) }
+    it { should have_many(:product_reviews).dependent(:destroy) }
+    it { should have_many(:product_subcategories).dependent(:destroy) }
     it { should have_many(:reviews).through(:product_reviews) }
     it { should have_many(:subcategories).through(:product_subcategories) }
     it { should have_many(:users).through(:product_requests) }


### PR DESCRIPTION
Add dependent deletion to relevant models. Also pairs down the NewRelic config file.

* Add dependent destroy to Product has_many through relationships
* Add dependent destroy to AtoType has_many through relationships
* Add dependent destroy to Category has_man through relationships
* Remove config options for NewRelic